### PR TITLE
Add domain to s3 resource settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ The entry should look like this:
   region: "us-east-1",
   tool: "example-app",
   type: "s3Folder",
-  allowedAccessRuleTypes: ["user", "context"] // optionally "readWriteToken", check AccessRuleType type for all allowed values
+  allowedAccessRuleTypes: ["user", "context"], // optionally "readWriteToken", check AccessRuleType type for all allowed values
+  domain: "https://cloudfront.domain.com" // optionally domain that will be used to construct public URL, usually a cloudfront domain
 ```
 
 ## Development Setup

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -1,5 +1,5 @@
-import {Credentials, Resource, FindAllQuery, CreateQuery, UpdateQuery, S3Resource, ReadWriteTokenAccessRule} from "../../functions/src/resource-types"
-import { getRWTokenFromAccessRules } from "../../functions/src/helpers";
+import {Credentials, Resource, FindAllQuery, CreateQuery, UpdateQuery, S3Resource } from "../../functions/src/resource-types"
+import { getRWTokenFromAccessRules } from "../../functions/src/common-helpers";
 export * from "../../functions/src/resource-types";
 
 type EnvironmentName = "dev" | "staging" | "production"

--- a/functions/src/base-resource-object.test.ts
+++ b/functions/src/base-resource-object.test.ts
@@ -1,6 +1,6 @@
-import { S3ResourceObject, IotResourceObject, BaseResourceObject } from "./resource";
+import { BaseResourceObject, S3ResourceObject, IotResourceObject } from "./base-resource-object";
 import { AccessRule, ReadWriteTokenAccessRule, ReadWriteTokenPrefix } from "./resource-types";
-import { JWTClaims } from "./firestore-types";
+import { FireStoreResourceSettings, JWTClaims } from "./firestore-types";
 import { STS, AWSError } from "aws-sdk";
 
 const expiration = new Date();
@@ -241,23 +241,40 @@ describe("Resource", () => {
   });
 
   describe("S3ResourceObject", () => {
-    it("should return an apiResult", () => {
-      expect(createS3Resource().apiResult(undefined)).toEqual({
-        id: "test",
-        name: "test",
-        description: "test",
-        type: "s3Folder",
-        tool: "glossary",
-        bucket: "test-bucket",
-        folder: "test-folder",
-        region: "test-region",
-        publicPath: "test-folder/test/",
-        publicUrl: "https://test-bucket.s3.amazonaws.com/test-folder/test/"
+    describe("apiResult", () => {
+      it("should return default public path based on bucket when settings don't include domain", () => {
+        expect(createS3Resource().apiResult(undefined, {} as FireStoreResourceSettings)).toEqual({
+          id: "test",
+          name: "test",
+          description: "test",
+          type: "s3Folder",
+          tool: "glossary",
+          bucket: "test-bucket",
+          folder: "test-folder",
+          region: "test-region",
+          publicPath: "test-folder/test/",
+          publicUrl: "https://test-bucket.s3.amazonaws.com/test-folder/test/"
+        });
+      });
+
+      it("should return custom public path based on bucket when settings include domain", () => {
+        expect(createS3Resource().apiResult(undefined, {domain: "https://cloudfront.domain.com"} as FireStoreResourceSettings)).toEqual({
+          id: "test",
+          name: "test",
+          description: "test",
+          type: "s3Folder",
+          tool: "glossary",
+          bucket: "test-bucket",
+          folder: "test-folder",
+          region: "test-region",
+          publicPath: "test-folder/test/",
+          publicUrl: "https://cloudfront.domain.com/test-folder/test/"
+        });
       });
     });
 
     it("should be capable of creating vortex configurations", () => {
-      expect(createS3VortexConfig().apiResult(undefined)).toEqual({
+      expect(createS3VortexConfig().apiResult(undefined, {} as FireStoreResourceSettings)).toEqual({
         bucket: "test-vortex-bucket",
         description: "test",
         folder: "test-vortex-folder",

--- a/functions/src/common-helpers.ts
+++ b/functions/src/common-helpers.ts
@@ -1,0 +1,16 @@
+// Note that this file is used by client code. It shouldn't depend on any other external libraries that are
+// not installed in the client.
+import { BaseResource, ReadWriteTokenAccessRule } from "./resource-types";
+
+export const getRWTokenFromAccessRules = (resource: BaseResource): string | undefined => {
+  if (!resource.accessRules) {
+    return undefined;
+  }
+  const readWriteTokenRules = resource.accessRules.filter(r => r.type === "readWriteToken");
+  if (readWriteTokenRules.length > 0) {
+    // There's no reason to have more than one readWriteToken rules (so in fact multiple read write tokens).
+    // But even if that happens, it's enough to get any of them to have access to the resource.
+    return (readWriteTokenRules[0] as ReadWriteTokenAccessRule).readWriteToken;
+  }
+  return undefined;
+};

--- a/functions/src/firestore-types.ts
+++ b/functions/src/firestore-types.ts
@@ -3,8 +3,8 @@ import { S3Resource, IotResource, AccessRuleType, ResourceType } from "./resourc
 export type FireStoreResource = FireStoreS3Resource | FireStoreIotOrganizationResource;
 
 // S3Resource is client-facing interface. Some of the fields are marked as optional (e.g. accessRules) as user
-// might not have access to them. Firestore version represents data stored in Firestore, so getters are omitted
-// and all the fields are marked as present/required.
+// might not have access to them. Firestore version represents data stored in Firestore, so getters/derived values
+// are omitted and all the fields are marked as present/required.
 export interface FireStoreS3Resource extends Required<Omit<S3Resource, "id" | "publicPath" | "publicUrl">> {
   type: "s3Folder"
 }
@@ -25,6 +25,8 @@ export interface FireStoreS3ResourceSettings extends ResourceSettings {
   bucket: string;
   folder: string;
   region: string;
+  // Optional domain, usually pointing to cloudfront distribution. It affects publicUrl of the resource.
+  domain?: string;
 }
 
 export interface FirestoreIotOrganizationSettings extends ResourceSettings {

--- a/functions/src/helpers.test.ts
+++ b/functions/src/helpers.test.ts
@@ -1,0 +1,30 @@
+import { makeCachedSettingsGetter } from "./helpers";
+import { BaseResourceObject } from "./base-resource-object";
+import { FireStoreResourceSettings } from "./firestore-types";
+
+describe("makeCachedSettingsGetter", () => {
+  const testDb = {} as FirebaseFirestore.Firestore;
+  const testSettings = { domain: "https://test.com" } as FireStoreResourceSettings;
+  beforeEach(() => {
+    BaseResourceObject.GetResourceSettings = jest.fn(() => Promise.resolve(testSettings));
+  });
+
+  it("provides catching and ensures db isn't hit multiple times for the same combination of resource type and tool", async () => {
+    const getSettings = makeCachedSettingsGetter(testDb, "test");
+    const settings = await getSettings("s3Folder", "test-app");
+    expect(settings).toEqual(testSettings);
+    expect(BaseResourceObject.GetResourceSettings).toHaveBeenCalledTimes(1);
+    await getSettings("s3Folder", "test-app");
+    expect(BaseResourceObject.GetResourceSettings).toHaveBeenCalledTimes(1);
+    await getSettings("s3Folder", "test-app");
+    expect(BaseResourceObject.GetResourceSettings).toHaveBeenCalledTimes(1);
+    await getSettings("iotOrganization", "test-app");
+    expect(BaseResourceObject.GetResourceSettings).toHaveBeenCalledTimes(2);
+    await getSettings("iotOrganization", "test-app");
+    expect(BaseResourceObject.GetResourceSettings).toHaveBeenCalledTimes(2);
+    await getSettings("s3Folder", "another-app");
+    expect(BaseResourceObject.GetResourceSettings).toHaveBeenCalledTimes(3);
+    await getSettings("s3Folder", "another-app");
+    expect(BaseResourceObject.GetResourceSettings).toHaveBeenCalledTimes(3);
+  });
+});

--- a/functions/src/helpers.ts
+++ b/functions/src/helpers.ts
@@ -1,19 +1,6 @@
-import { BaseResource, ReadWriteTokenAccessRule, ResourceType } from "./resource-types";
+import { ResourceType } from "./resource-types";
 import { FireStoreResourceSettings } from "./firestore-types";
 import { BaseResourceObject } from "./base-resource-object";
-
-export const getRWTokenFromAccessRules = (resource: BaseResource): string | undefined => {
-  if (!resource.accessRules) {
-    return undefined;
-  }
-  const readWriteTokenRules = resource.accessRules.filter(r => r.type === "readWriteToken");
-  if (readWriteTokenRules.length > 0) {
-    // There's no reason to have more than one readWriteToken rules (so in fact multiple read write tokens).
-    // But even if that happens, it's enough to get any of them to have access to the resource.
-    return (readWriteTokenRules[0] as ReadWriteTokenAccessRule).readWriteToken;
-  }
-  return undefined;
-};
 
 export const makeCachedSettingsGetter = (fsDb: FirebaseFirestore.Firestore, env: string) => {
   const settingsCache: {[key: string]: FireStoreResourceSettings} = {};

--- a/functions/src/helpers.ts
+++ b/functions/src/helpers.ts
@@ -1,4 +1,6 @@
-import { BaseResource, ReadWriteTokenAccessRule } from "./resource-types";
+import { BaseResource, ReadWriteTokenAccessRule, ResourceType } from "./resource-types";
+import { FireStoreResourceSettings } from "./firestore-types";
+import { BaseResourceObject } from "./base-resource-object";
 
 export const getRWTokenFromAccessRules = (resource: BaseResource): string | undefined => {
   if (!resource.accessRules) {
@@ -11,4 +13,25 @@ export const getRWTokenFromAccessRules = (resource: BaseResource): string | unde
     return (readWriteTokenRules[0] as ReadWriteTokenAccessRule).readWriteToken;
   }
   return undefined;
+};
+
+export const makeCachedSettingsGetter = (fsDb: FirebaseFirestore.Firestore, env: string) => {
+  const settingsCache: {[key: string]: FireStoreResourceSettings} = {};
+  return (type: ResourceType, tool: string) => {
+    return new Promise<FireStoreResourceSettings>((resolve, reject) => {
+      const key = type + tool;
+      if (!settingsCache[key]) {
+        // empty cache
+        BaseResourceObject.GetResourceSettings(fsDb, env, type, tool)
+          .then(settings => {
+            // cache settings and resolve promise
+            settingsCache[key] = settings;
+            resolve(settings)
+          })
+          .catch(reject);
+      } else {
+        resolve(settingsCache[key]);
+      }
+    });
+  };
 };

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -4,7 +4,8 @@ import * as express from 'express';
 import * as bodyParser from 'body-parser';
 import * as cors from 'cors';
 import { BaseResourceObject } from './base-resource-object';
-import { getRWTokenFromAccessRules, makeCachedSettingsGetter } from './helpers';
+import { getRWTokenFromAccessRules } from './common-helpers';
+import { makeCachedSettingsGetter } from './helpers'
 import { Config, ReadWriteTokenPrefix } from './resource-types';
 import { AuthClaims, JWTClaims } from './firestore-types';
 import { verify } from 'jsonwebtoken';


### PR DESCRIPTION
[#172289546]

There's a new field in resource settings called "domain". I didn't use cloudfront word here, as in fact it can be any domain, not necessarily related to cloudfront.

As I mentioned during standup, the domain is always read from settings. It's not copied directly to other resources like bucket name, folder name and region (should we leave that like this or start using settings objects for these values too?).

I've ended up extending `apiResult` method, as that's the only place where settings/domain is necessary. If I extended S3ResourceObject constructor, it would force us to obtain settings more often, e.g. for delete actions etc.

resources file is renamed to base-resource-object, as I wanted to divide this file into base-resource, s3-resource and iot-resource as @scytacki suggested previously. The problem is that it didn't work, as there are many circular references. BaseResourceObject is referencing its subclasses (S3ResourceObject, IotResourceObject) in many places. It only works when they're all together in one file somehow. I guess it'd be a separate chore to clean up all that.