### PR TITLE
Setup testing environment including firestore emulator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - cd client && travis_retry npm ci && cd ..
   - cd example-app && travis_retry npm ci && cd ..
 script:
-  - cd functions && npm run build && npm run test && cd ..
+  - cd functions && npm run build && npm run test:with-emulator && cd ..
   - cd client && npm run build && cd ..
   - cd example-app && npm run build && cd ..
   - mkdir -p dist/example-app && cp -R example-app/dist/. dist/example-app

--- a/README.md
+++ b/README.md
@@ -143,3 +143,11 @@ To start local server with example app:
 1. `cd functions` (all the commands below should be executed in `functions/` dir)
 2. Run `npm i` to load all the dependencies
 3. Run `npm start` to start all servers
+
+### Testing
+
+1. `cd functions` (all the commands below should be executed in `functions/` dir)
+2. `npm run test:with-emulator` starts Firestore emulator and run all the tests
+3. Alternatively, you can start emulator first using: `npm run firestore-emulator` and then use 
+   `npm test` or `npm run test:watch`. This is better for development, as emulator doesn't have to start 
+   and shutdown each time. 

--- a/firebase.json
+++ b/firebase.json
@@ -23,5 +23,10 @@
         "function": "webApiV1"
       }
     ]
+  },
+  "emulators": {
+    "firestore": {
+      "port": "8999"
+    }
   }
 }

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -380,15 +380,119 @@
         "minimist": "^1.2.0"
       }
     },
+    "@firebase/analytics": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.3.3.tgz",
+      "integrity": "sha512-Mj4lufHCnDqI2e8jAFqWmo9r2ejBJiGbI0MUvoiKVMxQm0kddQxUwmxfE6ozOAZ2HjB6OZ0iiAO+XU+0w/BnlA==",
+      "dev": true,
+      "requires": {
+        "@firebase/analytics-types": "0.3.0",
+        "@firebase/component": "0.1.10",
+        "@firebase/installations": "0.4.8",
+        "@firebase/logger": "0.2.2",
+        "@firebase/util": "0.2.45",
+        "tslib": "1.11.1"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.1.10",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.10.tgz",
+          "integrity": "sha512-Iy1+f8wp6mROz19oxWUd31NxMlGxtW1IInGHITnVa6eZtXOg0lxcbgYeLp9W3PKzvvNfshHU0obDkcMY97zRAw==",
+          "dev": true,
+          "requires": {
+            "@firebase/util": "0.2.45",
+            "tslib": "1.11.1"
+          }
+        },
+        "@firebase/logger": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.2.tgz",
+          "integrity": "sha512-MbEy17Ha1w/DlLtvxG89ScQ+0+yoElGKJ1nUCQHHLjeMNsRwd2wnUPOVCsZvtBzQp8Z0GaFmD4a2iG2v91lEbA==",
+          "dev": true
+        },
+        "@firebase/util": {
+          "version": "0.2.45",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.45.tgz",
+          "integrity": "sha512-k3IqXaIgwlPg7m5lXmMUtkqA/p+LMFkFQIqBuDtdT0iyWB6kQDokyjw2Sgd3GoTybs6tWqUKFZupZpV6r73UHw==",
+          "dev": true,
+          "requires": {
+            "tslib": "1.11.1"
+          }
+        }
+      }
+    },
+    "@firebase/analytics-types": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.3.0.tgz",
+      "integrity": "sha512-0AJ6xn53Qn0D/YOVHHvlWFfnzzRSdd98Lr8Oqe1PJ2HPIN+o7qf03YmOG7fLpR1uplcWd+7vGKmxUrN3jKUBwg==",
+      "dev": true
+    },
+    "@firebase/app": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.2.tgz",
+      "integrity": "sha512-rAxc90+82GAPpUxS02EO0dys4+TeQ6XjFjCwQz/OVptGeLgxN9ZoXYAf/bxyeYOdLxJW0kbEKE/0xXaJDt5gsg==",
+      "dev": true,
+      "requires": {
+        "@firebase/app-types": "0.6.0",
+        "@firebase/component": "0.1.10",
+        "@firebase/logger": "0.2.2",
+        "@firebase/util": "0.2.45",
+        "dom-storage": "2.1.0",
+        "tslib": "1.11.1",
+        "xmlhttprequest": "1.8.0"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.1.10",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.10.tgz",
+          "integrity": "sha512-Iy1+f8wp6mROz19oxWUd31NxMlGxtW1IInGHITnVa6eZtXOg0lxcbgYeLp9W3PKzvvNfshHU0obDkcMY97zRAw==",
+          "dev": true,
+          "requires": {
+            "@firebase/util": "0.2.45",
+            "tslib": "1.11.1"
+          }
+        },
+        "@firebase/logger": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.2.tgz",
+          "integrity": "sha512-MbEy17Ha1w/DlLtvxG89ScQ+0+yoElGKJ1nUCQHHLjeMNsRwd2wnUPOVCsZvtBzQp8Z0GaFmD4a2iG2v91lEbA==",
+          "dev": true
+        },
+        "@firebase/util": {
+          "version": "0.2.45",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.45.tgz",
+          "integrity": "sha512-k3IqXaIgwlPg7m5lXmMUtkqA/p+LMFkFQIqBuDtdT0iyWB6kQDokyjw2Sgd3GoTybs6tWqUKFZupZpV6r73UHw==",
+          "dev": true,
+          "requires": {
+            "tslib": "1.11.1"
+          }
+        }
+      }
+    },
     "@firebase/app-types": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.0.tgz",
       "integrity": "sha512-ld6rzjXk/SUauHiQZJkeuSJpxIZ5wdnWuF5fWBFQNPaxsaJ9kyYg9GqEvwZ1z2e6JP5cU9gwRBlfW1WkGtGDYA=="
     },
+    "@firebase/auth": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.14.3.tgz",
+      "integrity": "sha512-XPB3Mf3PwHibv2HbvqOol02ACCuwAKSY9HAtq70w3K3OwSDX4opDdrNOhoer7Nrq3xvX58b+c+oVGxD9mbo/qQ==",
+      "dev": true,
+      "requires": {
+        "@firebase/auth-types": "0.10.0"
+      }
+    },
     "@firebase/auth-interop-types": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.4.tgz",
       "integrity": "sha512-CLKNS84KGAv5lRnHTQZFWoR11Ti7gIPFirDDXWek/fSU+TdYdnxJFR5XSD4OuGyzUYQ3Dq7aVj5teiRdyBl9hA=="
+    },
+    "@firebase/auth-types": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.10.0.tgz",
+      "integrity": "sha512-VuW7c+RAk3AYPU0Hxmun3RzXn7fbJDdjQbxvvpRMnQ9zrhk8mH42cY466M0n4e/UGQ+0smlx5BqZII8aYQ5XPg==",
+      "dev": true
     },
     "@firebase/component": {
       "version": "0.1.9",
@@ -421,10 +525,371 @@
         "@firebase/app-types": "0.6.0"
       }
     },
+    "@firebase/firestore": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-1.14.1.tgz",
+      "integrity": "sha512-6wu+Oh00O8NPWyetr8BVZ9Y3Z7PrBZpoJjam2jjB0RVOaksvC1VTmjIOK6cLczt9hD0JRtb5wy+ME7E70N0ruA==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.1.10",
+        "@firebase/firestore-types": "1.10.1",
+        "@firebase/logger": "0.2.2",
+        "@firebase/util": "0.2.45",
+        "@firebase/webchannel-wrapper": "0.2.39",
+        "@grpc/grpc-js": "0.8.1",
+        "@grpc/proto-loader": "^0.5.0",
+        "tslib": "1.11.1"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.1.10",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.10.tgz",
+          "integrity": "sha512-Iy1+f8wp6mROz19oxWUd31NxMlGxtW1IInGHITnVa6eZtXOg0lxcbgYeLp9W3PKzvvNfshHU0obDkcMY97zRAw==",
+          "dev": true,
+          "requires": {
+            "@firebase/util": "0.2.45",
+            "tslib": "1.11.1"
+          }
+        },
+        "@firebase/logger": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.2.tgz",
+          "integrity": "sha512-MbEy17Ha1w/DlLtvxG89ScQ+0+yoElGKJ1nUCQHHLjeMNsRwd2wnUPOVCsZvtBzQp8Z0GaFmD4a2iG2v91lEbA==",
+          "dev": true
+        },
+        "@firebase/util": {
+          "version": "0.2.45",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.45.tgz",
+          "integrity": "sha512-k3IqXaIgwlPg7m5lXmMUtkqA/p+LMFkFQIqBuDtdT0iyWB6kQDokyjw2Sgd3GoTybs6tWqUKFZupZpV6r73UHw==",
+          "dev": true,
+          "requires": {
+            "tslib": "1.11.1"
+          }
+        },
+        "@grpc/grpc-js": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-0.8.1.tgz",
+          "integrity": "sha512-e8gSjRZnOUefsR3obOgxG9RtYW2Mw83hh7ogE2ByCdgRhoX0mdnJwBcZOami3E0l643KCTZvORFwfSEi48KFIQ==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.2.0"
+          }
+        }
+      }
+    },
+    "@firebase/firestore-types": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-1.10.1.tgz",
+      "integrity": "sha512-vyKdm+AYUFT8XeUX62IOqaqPFCs/mAMoSEsqIz9HnSVsqCw/IocNjtjSa+3M80kRw4V8fI7JI+Xz6Wg5VJXLqA==",
+      "dev": true
+    },
+    "@firebase/functions": {
+      "version": "0.4.41",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.4.41.tgz",
+      "integrity": "sha512-S7fYjzoCSWoTUpTvYRXHYByXdNIP7TYFkfBGvy/ca1WT/6AnBOkdFuxPLilEaKWKlERMbYUQgxyNq52nUPRhCw==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.1.10",
+        "@firebase/functions-types": "0.3.16",
+        "@firebase/messaging-types": "0.4.4",
+        "isomorphic-fetch": "2.2.1",
+        "tslib": "1.11.1"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.1.10",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.10.tgz",
+          "integrity": "sha512-Iy1+f8wp6mROz19oxWUd31NxMlGxtW1IInGHITnVa6eZtXOg0lxcbgYeLp9W3PKzvvNfshHU0obDkcMY97zRAw==",
+          "dev": true,
+          "requires": {
+            "@firebase/util": "0.2.45",
+            "tslib": "1.11.1"
+          }
+        },
+        "@firebase/util": {
+          "version": "0.2.45",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.45.tgz",
+          "integrity": "sha512-k3IqXaIgwlPg7m5lXmMUtkqA/p+LMFkFQIqBuDtdT0iyWB6kQDokyjw2Sgd3GoTybs6tWqUKFZupZpV6r73UHw==",
+          "dev": true,
+          "requires": {
+            "tslib": "1.11.1"
+          }
+        }
+      }
+    },
+    "@firebase/functions-types": {
+      "version": "0.3.16",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.3.16.tgz",
+      "integrity": "sha512-kHhBvSYiY2prY4vNQCALYs1+OruTdylvGemHG6G6Bs/rj3qw7ui3WysBsDU/rInJitHIcsZ35qrtanoJeQUIXQ==",
+      "dev": true
+    },
+    "@firebase/installations": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.8.tgz",
+      "integrity": "sha512-J3tyKCdZ07LR0Bw3rs4CIsWia5exGt77fdbvqnhYa6K8YfIUPFLzsGRvlFJkoIhOMXfujfnC3O/DakROOgOltg==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.1.10",
+        "@firebase/installations-types": "0.3.3",
+        "@firebase/util": "0.2.45",
+        "idb": "3.0.2",
+        "tslib": "1.11.1"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.1.10",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.10.tgz",
+          "integrity": "sha512-Iy1+f8wp6mROz19oxWUd31NxMlGxtW1IInGHITnVa6eZtXOg0lxcbgYeLp9W3PKzvvNfshHU0obDkcMY97zRAw==",
+          "dev": true,
+          "requires": {
+            "@firebase/util": "0.2.45",
+            "tslib": "1.11.1"
+          }
+        },
+        "@firebase/util": {
+          "version": "0.2.45",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.45.tgz",
+          "integrity": "sha512-k3IqXaIgwlPg7m5lXmMUtkqA/p+LMFkFQIqBuDtdT0iyWB6kQDokyjw2Sgd3GoTybs6tWqUKFZupZpV6r73UHw==",
+          "dev": true,
+          "requires": {
+            "tslib": "1.11.1"
+          }
+        }
+      }
+    },
+    "@firebase/installations-types": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.3.3.tgz",
+      "integrity": "sha512-XvWhPPAGeZlc+CfCA8jTt2pv19Jovi/nUV73u30QbjBbk5xci9bp5I29aBZukHsR6YNBjFCLSkLPbno4m/bLUg==",
+      "dev": true
+    },
     "@firebase/logger": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.1.tgz",
       "integrity": "sha512-H4nttTqUzEw3TA/JYl8ma6oMSNKHcdpEWV2L2qA+ZEcpM2OLAzagi//DrYBFR5xpPb17IGagpzSxFgx937Sq/A=="
+    },
+    "@firebase/messaging": {
+      "version": "0.6.13",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.6.13.tgz",
+      "integrity": "sha512-QfC1H88q+YYjqzrmplzRwUsVfDJpVB+AaUnv6SPBoh12Eh/Wutu+ot8h6rpEc1b0B69EGYD/Pu2+bnixYVhlUA==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.1.10",
+        "@firebase/installations": "0.4.8",
+        "@firebase/messaging-types": "0.4.4",
+        "@firebase/util": "0.2.45",
+        "idb": "3.0.2",
+        "tslib": "1.11.1"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.1.10",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.10.tgz",
+          "integrity": "sha512-Iy1+f8wp6mROz19oxWUd31NxMlGxtW1IInGHITnVa6eZtXOg0lxcbgYeLp9W3PKzvvNfshHU0obDkcMY97zRAw==",
+          "dev": true,
+          "requires": {
+            "@firebase/util": "0.2.45",
+            "tslib": "1.11.1"
+          }
+        },
+        "@firebase/util": {
+          "version": "0.2.45",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.45.tgz",
+          "integrity": "sha512-k3IqXaIgwlPg7m5lXmMUtkqA/p+LMFkFQIqBuDtdT0iyWB6kQDokyjw2Sgd3GoTybs6tWqUKFZupZpV6r73UHw==",
+          "dev": true,
+          "requires": {
+            "tslib": "1.11.1"
+          }
+        }
+      }
+    },
+    "@firebase/messaging-types": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-types/-/messaging-types-0.4.4.tgz",
+      "integrity": "sha512-JGtkr+1A1Dw7+yCqQigqBfGKtq0gTCruFScBD4MVjqZHiqGIYpnQisWnpGbkzPR6aOt6iQxgwxUhHG1ulUQGeg==",
+      "dev": true
+    },
+    "@firebase/performance": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.3.1.tgz",
+      "integrity": "sha512-YBs3iIGNZM39Yas4AU9BFZS4na1J/yoARVUGsL0Vcvw6TaPN57KiqKdfbjxz84WSuC3xrDa6Hirxh9S1sS0zbQ==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.1.10",
+        "@firebase/installations": "0.4.8",
+        "@firebase/logger": "0.2.2",
+        "@firebase/performance-types": "0.0.12",
+        "@firebase/util": "0.2.45",
+        "tslib": "1.11.1"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.1.10",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.10.tgz",
+          "integrity": "sha512-Iy1+f8wp6mROz19oxWUd31NxMlGxtW1IInGHITnVa6eZtXOg0lxcbgYeLp9W3PKzvvNfshHU0obDkcMY97zRAw==",
+          "dev": true,
+          "requires": {
+            "@firebase/util": "0.2.45",
+            "tslib": "1.11.1"
+          }
+        },
+        "@firebase/logger": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.2.tgz",
+          "integrity": "sha512-MbEy17Ha1w/DlLtvxG89ScQ+0+yoElGKJ1nUCQHHLjeMNsRwd2wnUPOVCsZvtBzQp8Z0GaFmD4a2iG2v91lEbA==",
+          "dev": true
+        },
+        "@firebase/util": {
+          "version": "0.2.45",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.45.tgz",
+          "integrity": "sha512-k3IqXaIgwlPg7m5lXmMUtkqA/p+LMFkFQIqBuDtdT0iyWB6kQDokyjw2Sgd3GoTybs6tWqUKFZupZpV6r73UHw==",
+          "dev": true,
+          "requires": {
+            "tslib": "1.11.1"
+          }
+        }
+      }
+    },
+    "@firebase/performance-types": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.0.12.tgz",
+      "integrity": "sha512-eIDF7CHetOE5sc+hCaUebEn/2Aiaju7UkgZDTl7lNQHz5fK9wJ/11HaE8WdnDr//ngS3lQAGC2RB4lAZeEWraA==",
+      "dev": true
+    },
+    "@firebase/polyfill": {
+      "version": "0.3.34",
+      "resolved": "https://registry.npmjs.org/@firebase/polyfill/-/polyfill-0.3.34.tgz",
+      "integrity": "sha512-6EN02vwhX6cmyB4YswKhHkS3kMeNDxjCgf4vR3L9wYv+A5QVgAM85ifzf3mZT0tq3f2LfIsTsCIr/mlz2Swl1A==",
+      "dev": true,
+      "requires": {
+        "core-js": "3.6.5",
+        "promise-polyfill": "8.1.3",
+        "whatwg-fetch": "2.0.4"
+      },
+      "dependencies": {
+        "whatwg-fetch": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+          "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/remote-config": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.19.tgz",
+      "integrity": "sha512-2n6bavDGO+cQsS3fs+yHthnkp5TKh8sqSD89dztt/b3/KKRb4C89r3apb6QIcQw/AlyToM+NyU6WIZyXfVAhqQ==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.1.10",
+        "@firebase/installations": "0.4.8",
+        "@firebase/logger": "0.2.2",
+        "@firebase/remote-config-types": "0.1.8",
+        "@firebase/util": "0.2.45",
+        "tslib": "1.11.1"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.1.10",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.10.tgz",
+          "integrity": "sha512-Iy1+f8wp6mROz19oxWUd31NxMlGxtW1IInGHITnVa6eZtXOg0lxcbgYeLp9W3PKzvvNfshHU0obDkcMY97zRAw==",
+          "dev": true,
+          "requires": {
+            "@firebase/util": "0.2.45",
+            "tslib": "1.11.1"
+          }
+        },
+        "@firebase/logger": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.2.tgz",
+          "integrity": "sha512-MbEy17Ha1w/DlLtvxG89ScQ+0+yoElGKJ1nUCQHHLjeMNsRwd2wnUPOVCsZvtBzQp8Z0GaFmD4a2iG2v91lEbA==",
+          "dev": true
+        },
+        "@firebase/util": {
+          "version": "0.2.45",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.45.tgz",
+          "integrity": "sha512-k3IqXaIgwlPg7m5lXmMUtkqA/p+LMFkFQIqBuDtdT0iyWB6kQDokyjw2Sgd3GoTybs6tWqUKFZupZpV6r73UHw==",
+          "dev": true,
+          "requires": {
+            "tslib": "1.11.1"
+          }
+        }
+      }
+    },
+    "@firebase/remote-config-types": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.1.8.tgz",
+      "integrity": "sha512-K12IBHO7OD4gCW0FEqZL9zMqVAfS4+joC4YIn3bHezZfu3RL+Bw1wCb0cAD7RfDPcQxWJjxOHpce4YhuqSxPFA==",
+      "dev": true
+    },
+    "@firebase/storage": {
+      "version": "0.3.32",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.3.32.tgz",
+      "integrity": "sha512-mwWI03VbTd1jP7mmeNBv7mJ96i8GUX1fSxVept5aV2FQb2pAWTKXr7Gmxg06w642I0T1+qZTRVXs8G5m8vuTjg==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.1.10",
+        "@firebase/storage-types": "0.3.11",
+        "@firebase/util": "0.2.45",
+        "tslib": "1.11.1"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.1.10",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.10.tgz",
+          "integrity": "sha512-Iy1+f8wp6mROz19oxWUd31NxMlGxtW1IInGHITnVa6eZtXOg0lxcbgYeLp9W3PKzvvNfshHU0obDkcMY97zRAw==",
+          "dev": true,
+          "requires": {
+            "@firebase/util": "0.2.45",
+            "tslib": "1.11.1"
+          }
+        },
+        "@firebase/util": {
+          "version": "0.2.45",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.45.tgz",
+          "integrity": "sha512-k3IqXaIgwlPg7m5lXmMUtkqA/p+LMFkFQIqBuDtdT0iyWB6kQDokyjw2Sgd3GoTybs6tWqUKFZupZpV6r73UHw==",
+          "dev": true,
+          "requires": {
+            "tslib": "1.11.1"
+          }
+        }
+      }
+    },
+    "@firebase/storage-types": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.3.11.tgz",
+      "integrity": "sha512-EMOo5aeiJIa8eQ/VqjIa/DYlDcEJX1V84FOxmLfNWZIlmCSvcqx9E9mcNlOnoUB4iePqQjTMQRtKlIBvvEVhVg==",
+      "dev": true
+    },
+    "@firebase/testing": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@firebase/testing/-/testing-0.19.1.tgz",
+      "integrity": "sha512-uTqgjJlv4KLio6a5GxwhUL4rPefqoPR7uAaqdE4AETZBVj7shCq/E+Qy613oFlbtrWdUNhKW5vFBZkKWjLrKVQ==",
+      "dev": true,
+      "requires": {
+        "@firebase/logger": "0.2.2",
+        "@firebase/util": "0.2.45",
+        "@types/request": "2.48.4",
+        "firebase": "7.14.1",
+        "request": "2.88.2"
+      },
+      "dependencies": {
+        "@firebase/logger": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.2.tgz",
+          "integrity": "sha512-MbEy17Ha1w/DlLtvxG89ScQ+0+yoElGKJ1nUCQHHLjeMNsRwd2wnUPOVCsZvtBzQp8Z0GaFmD4a2iG2v91lEbA==",
+          "dev": true
+        },
+        "@firebase/util": {
+          "version": "0.2.45",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.45.tgz",
+          "integrity": "sha512-k3IqXaIgwlPg7m5lXmMUtkqA/p+LMFkFQIqBuDtdT0iyWB6kQDokyjw2Sgd3GoTybs6tWqUKFZupZpV6r73UHw==",
+          "dev": true,
+          "requires": {
+            "tslib": "1.11.1"
+          }
+        }
+      }
     },
     "@firebase/util": {
       "version": "0.2.44",
@@ -433,6 +898,12 @@
       "requires": {
         "tslib": "1.11.1"
       }
+    },
+    "@firebase/webchannel-wrapper": {
+      "version": "0.2.39",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.2.39.tgz",
+      "integrity": "sha512-V5oQjtYxHlEpWdQr68ZFo8T+3NVccrTieRy8RnzYIasCeptxOxwYUG0cAAKmalgrrrfRJdXup8h5ybi3XSW9Hw==",
+      "dev": true
     },
     "@google-cloud/common": {
       "version": "2.4.0",
@@ -452,9 +923,9 @@
       }
     },
     "@google-cloud/firestore": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-3.7.3.tgz",
-      "integrity": "sha512-6ro45y5FjSbJCRHUQ8PfIu2EbnGNNVoQmKtBnI1YlhlVHaC7oMu+m0cuI0Cr3lLs1mT5iZ0QGyjHTeUYR8pygw==",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-3.7.4.tgz",
+      "integrity": "sha512-RBMG4uZFHeQPFMHTRFMyQ7LDQTLa0f+U0hLAa/7XWjpZHgxKuOWBonsv+C3geymAwShIZSoV/NpNh9tBK7YF5g==",
       "optional": true,
       "requires": {
         "deep-equal": "^2.0.0",
@@ -719,6 +1190,12 @@
             "@types/yargs-parser": "*"
           }
         },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
         "ansi-styles": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
@@ -759,6 +1236,15 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
         },
         "supports-color": {
           "version": "7.1.0",
@@ -1034,6 +1520,16 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
+        },
+        "string-length": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-length/-/string-length-3.1.0.tgz",
+          "integrity": "sha512-Ttp5YvkGm5v9Ijagtaz1BnN+k9ObpvS0eIBblPMp2YWL8FBmi9qblQ9fexc2k/CXFgrTIteU3jAw3payCnwSTA==",
+          "dev": true,
+          "requires": {
+            "astral-regex": "^1.0.0",
+            "strip-ansi": "^5.2.0"
+          }
         },
         "supports-color": {
           "version": "7.1.0",
@@ -1381,6 +1877,12 @@
         "@types/node": "*"
       }
     },
+    "@types/caseless": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
+      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
+      "dev": true
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -1394,6 +1896,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/cookiejar": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.1.tgz",
+      "integrity": "sha512-aRnpPa7ysx3aNW60hTiCtLHlQaIFsXFCgQlpakNgDNVFzbtusSY8PwjAQgRWfSk0ekNoBjO51eQRB6upA9uuyw==",
+      "dev": true
     },
     "@types/cors": {
       "version": "2.8.6",
@@ -1413,9 +1921,9 @@
       }
     },
     "@types/express": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.5.tgz",
-      "integrity": "sha512-u4Si7vYAjy5/UyRFa8EoqLHh6r82xOZPbWRQHlSf6alob0rlyza7EkU0RbR8kOZqgWp6R5+aRcHMYYby7w12Bg==",
+      "version": "4.17.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.6.tgz",
+      "integrity": "sha512-n/mr9tZI83kd4azlPG5y997C/M4DNABK9yErhFM6hKdym4kkmd9j0vtsJyjFIwfRBxtrxZtAfGZCNRIBMFLK5w==",
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "*",
@@ -1424,9 +1932,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.4.tgz",
-      "integrity": "sha512-dPs6CaRWxsfHbYDVU51VjEJaUJEcli4UI0fFMT4oWmgCvHj+j7oIxz5MLHVL0Rv++N004c21ylJNdWQvPkkb5w==",
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.5.tgz",
+      "integrity": "sha512-578YH5Lt88AKoADy0b2jQGwJtrBxezXtVe/MBqWXKZpqx91SnC0pVkVCcxcytz3lWW+cHBYDi3Ysh0WXc+rAYw==",
       "requires": {
         "@types/node": "*",
         "@types/range-parser": "*"
@@ -1520,6 +2028,18 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
       "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
     },
+    "@types/request": {
+      "version": "2.48.4",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.4.tgz",
+      "integrity": "sha512-W1t1MTKYR8PxICH+A4HgEIPuAC3sbljoEVfyZbeFJJDbr30guDspJri2XOaM2E+Un7ZjrihaDi7cf6fPa2tbgw==",
+      "dev": true,
+      "requires": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.0"
+      }
+    },
     "@types/serve-static": {
       "version": "1.13.3",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.3.tgz",
@@ -1533,6 +2053,31 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
+      "dev": true
+    },
+    "@types/superagent": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-4.1.7.tgz",
+      "integrity": "sha512-JSwNPgRYjIC4pIeOqLwWwfGj6iP1n5NE6kNBEbGx2V8H78xCPwx7QpNp9plaI30+W3cFEzJO7BIIsXE+dbtaGg==",
+      "dev": true,
+      "requires": {
+        "@types/cookiejar": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/supertest": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-2.0.8.tgz",
+      "integrity": "sha512-wcax7/ip4XSSJRLbNzEIUVy2xjcBIZZAuSd2vtltQfRK7kxhx5WMHbLHkYdxN3wuQCrwpYrg86/9byDjPXoGMA==",
+      "dev": true,
+      "requires": {
+        "@types/superagent": "*"
+      }
+    },
+    "@types/tough-cookie": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==",
       "dev": true
     },
     "@types/yargs": {
@@ -1661,12 +2206,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "string-width": {
@@ -1905,9 +2444,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.656.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.656.0.tgz",
-      "integrity": "sha512-UzqDvvt6i7gpuzEdK0GT/JOfBJcsCPranzZWdQ9HR4+5E0m5kf5gybZ6OX+UseIAE2/WND6Dv0aHgiI21AKenw==",
+      "version": "2.657.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.657.0.tgz",
+      "integrity": "sha512-CGxnYEFkZwIflH0cnylMtyNNmjkQIK5gG9L0MRGha4ANSogBrCXfWcjSWP1ziDK0FhRBAyJVdMX0il/kW4ya+A==",
       "requires": {
         "buffer": "4.9.1",
         "events": "1.1.1",
@@ -2199,9 +2738,9 @@
       },
       "dependencies": {
         "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
           "dev": true,
           "requires": {
             "base64-js": "^1.0.2",
@@ -2264,12 +2803,6 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "string-width": {
@@ -2517,9 +3050,9 @@
       "dev": true
     },
     "ci-info": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
       "dev": true
     },
     "cjson": {
@@ -2607,9 +3140,9 @@
       }
     },
     "cli-width": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
       "dev": true
     },
     "cliui": {
@@ -2621,6 +3154,23 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^6.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
       }
     },
     "clone": {
@@ -2898,10 +3448,22 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
+      "dev": true
+    },
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
+    "core-js": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
       "dev": true
     },
     "core-util-is": {
@@ -2928,9 +3490,9 @@
       },
       "dependencies": {
         "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
           "dev": true,
           "requires": {
             "base64-js": "^1.0.2",
@@ -3292,6 +3854,12 @@
       "integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==",
       "dev": true
     },
+    "dom-storage": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/dom-storage/-/dom-storage-2.1.0.tgz",
+      "integrity": "sha512-g6RpyWXzl0RR6OTElHKBl7nwnK87GUyZMYC7JWsB/IA73vpqK2K6LT39x4VepLxlSsWBFrPVLnsSR5Jyty0+2Q==",
+      "dev": true
+    },
     "domexception": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
@@ -3416,6 +3984,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -3620,6 +4197,15 @@
         "strip-eof": "^1.0.0"
       },
       "dependencies": {
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
         "is-stream": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -4039,6 +4625,79 @@
         "path-exists": "^4.0.0"
       }
     },
+    "firebase": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-7.14.1.tgz",
+      "integrity": "sha512-2lgBgWuFOd9wnwgOQEKmqqxuWf2Cp2xw08Nwar8/fD5gtoMngn7JY2PE86VUSu7XVTyhVFLfAIAMyZLDaRRTOg==",
+      "dev": true,
+      "requires": {
+        "@firebase/analytics": "0.3.3",
+        "@firebase/app": "0.6.2",
+        "@firebase/app-types": "0.6.0",
+        "@firebase/auth": "0.14.3",
+        "@firebase/database": "0.6.1",
+        "@firebase/firestore": "1.14.1",
+        "@firebase/functions": "0.4.41",
+        "@firebase/installations": "0.4.8",
+        "@firebase/messaging": "0.6.13",
+        "@firebase/performance": "0.3.1",
+        "@firebase/polyfill": "0.3.34",
+        "@firebase/remote-config": "0.1.19",
+        "@firebase/storage": "0.3.32",
+        "@firebase/util": "0.2.45"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.1.10",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.10.tgz",
+          "integrity": "sha512-Iy1+f8wp6mROz19oxWUd31NxMlGxtW1IInGHITnVa6eZtXOg0lxcbgYeLp9W3PKzvvNfshHU0obDkcMY97zRAw==",
+          "dev": true,
+          "requires": {
+            "@firebase/util": "0.2.45",
+            "tslib": "1.11.1"
+          }
+        },
+        "@firebase/database": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.6.1.tgz",
+          "integrity": "sha512-7XqUbj3nK2vEdFjGOXBfKISmpLrM0caIwwfDPxhn6i7X/g6AIH+D1limH+Jit4QeKMh/IJZDNqO7P+Fz+e8q1Q==",
+          "dev": true,
+          "requires": {
+            "@firebase/auth-interop-types": "0.1.4",
+            "@firebase/component": "0.1.10",
+            "@firebase/database-types": "0.5.0",
+            "@firebase/logger": "0.2.2",
+            "@firebase/util": "0.2.45",
+            "faye-websocket": "0.11.3",
+            "tslib": "1.11.1"
+          }
+        },
+        "@firebase/database-types": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.5.0.tgz",
+          "integrity": "sha512-6/W3frFznYOALtw2nrWVPK2ytgdl89CzTqVBHCCGf22wT6uKU63iDBo+Nw+7olFGpD15O0zwYalFIcMZ27tkew==",
+          "dev": true,
+          "requires": {
+            "@firebase/app-types": "0.6.0"
+          }
+        },
+        "@firebase/logger": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.2.tgz",
+          "integrity": "sha512-MbEy17Ha1w/DlLtvxG89ScQ+0+yoElGKJ1nUCQHHLjeMNsRwd2wnUPOVCsZvtBzQp8Z0GaFmD4a2iG2v91lEbA==",
+          "dev": true
+        },
+        "@firebase/util": {
+          "version": "0.2.45",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.45.tgz",
+          "integrity": "sha512-k3IqXaIgwlPg7m5lXmMUtkqA/p+LMFkFQIqBuDtdT0iyWB6kQDokyjw2Sgd3GoTybs6tWqUKFZupZpV6r73UHw==",
+          "dev": true,
+          "requires": {
+            "tslib": "1.11.1"
+          }
+        }
+      }
+    },
     "firebase-admin": {
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-8.10.0.tgz",
@@ -4054,9 +4713,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.10.59",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.59.tgz",
-          "integrity": "sha512-8RkBivJrDCyPpBXhVZcjh7cQxVBSmRk9QM7hOketZzp6Tg79c0N8kkpAIito9bnJ3HCVCHVYz+KHTEbfQNfeVQ=="
+          "version": "8.10.60",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.60.tgz",
+          "integrity": "sha512-YjPbypHFuiOV0bTgeF07HpEEqhmHaZqYNSdCKeBJa+yFoQ/7BC+FpJcwmi34xUIIRVFktnUyP1dPU8U0612GOg=="
         },
         "jsonwebtoken": {
           "version": "8.1.0",
@@ -4119,9 +4778,9 @@
       }
     },
     "firebase-tools": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-8.0.2.tgz",
-      "integrity": "sha512-rvWCRIqJALhh2TMa/Zt3kJrrywGF+2uJAbBGl0y5hQXSy3x9CTfi7M1P6ohGYNUbYWNYsxhhbjLemMLOc4SrFw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-8.1.0.tgz",
+      "integrity": "sha512-HHoWDypaYMQPWMHVSFathW2eDa6fvQNP7JcnpdZEPrNlOiw/xOHnc98R1ak+usar6OAEwW9uHkBXSG2V/wK+kA==",
       "dev": true,
       "requires": {
         "@google-cloud/pubsub": "^1.7.0",
@@ -4135,7 +4794,7 @@
         "commander": "^4.0.1",
         "configstore": "^5.0.1",
         "cross-env": "^5.1.3",
-        "cross-spawn": "^4.0.0",
+        "cross-spawn": "^7.0.1",
         "csv-streamify": "^3.0.4",
         "didyoumean": "^1.2.1",
         "dotenv": "^6.1.0",
@@ -4199,13 +4858,14 @@
           "dev": true
         },
         "cross-spawn": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
+          "integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
           "dev": true,
           "requires": {
-            "lru-cache": "^4.0.1",
-            "which": "^1.2.9"
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
           }
         },
         "google-gax": {
@@ -4238,15 +4898,11 @@
             }
           }
         },
-        "lru-cache": {
-          "version": "4.1.5",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-          "dev": true,
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
         },
         "semver": {
           "version": "5.7.1",
@@ -4254,19 +4910,19 @@
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         },
-        "which": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
           "dev": true,
           "requires": {
-            "isexe": "^2.0.0"
+            "shebang-regex": "^3.0.0"
           }
         },
-        "yallist": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
           "dev": true
         }
       }
@@ -4338,15 +4994,21 @@
       "dev": true
     },
     "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
       "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
+    },
+    "formidable": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
+      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q==",
+      "dev": true
     },
     "forwarded": {
       "version": "0.1.2",
@@ -4509,13 +5171,10 @@
       "dev": true
     },
     "get-stream": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-      "dev": true,
-      "requires": {
-        "pump": "^3.0.0"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+      "dev": true
     },
     "get-value": {
       "version": "2.0.6",
@@ -4659,12 +5318,6 @@
         "url-parse-lax": "^1.0.0"
       },
       "dependencies": {
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-          "dev": true
-        },
         "is-stream": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -4958,6 +5611,12 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "idb": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-3.0.2.tgz",
+      "integrity": "sha512-+FLa/0sTXqyux0o6C+i2lOR0VoS60LU/jzUo5xjfY6+7sEEgy4Gz1O7yFBXvjd7N0NyIGWIRg8DcQSLEG+VSPw==",
+      "dev": true
+    },
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -5038,12 +5697,6 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -5062,23 +5715,6 @@
               "requires": {
                 "ansi-regex": "^3.0.0"
               }
-            }
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-              "dev": true
             }
           }
         }
@@ -5160,12 +5796,12 @@
       "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
     },
     "is-ci": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
-      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+      "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
       "dev": true,
       "requires": {
-        "ci-info": "^2.0.0"
+        "ci-info": "^1.5.0"
       }
     },
     "is-data-descriptor": {
@@ -5225,9 +5861,9 @@
       "dev": true
     },
     "is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
     },
     "is-generator-fn": {
@@ -5434,6 +6070,34 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      },
+      "dependencies": {
+        "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+          "dev": true
+        },
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        }
+      }
+    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -5579,6 +6243,12 @@
             "supports-color": "^7.1.0"
           }
         },
+        "ci-info": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+          "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+          "dev": true
+        },
         "color-convert": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -5599,6 +6269,15 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
+        },
+        "is-ci": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+          "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+          "dev": true,
+          "requires": {
+            "ci-info": "^2.0.0"
+          }
         },
         "jest-cli": {
           "version": "25.3.0",
@@ -7422,6 +8101,12 @@
             "supports-color": "^7.1.0"
           }
         },
+        "ci-info": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+          "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+          "dev": true
+        },
         "color-convert": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -7442,6 +8127,15 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
+        },
+        "is-ci": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+          "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+          "dev": true,
+          "requires": {
+            "ci-info": "^2.0.0"
+          }
         },
         "supports-color": {
           "version": "7.1.0",
@@ -7640,6 +8334,16 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
+        },
+        "string-length": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-length/-/string-length-3.1.0.tgz",
+          "integrity": "sha512-Ttp5YvkGm5v9Ijagtaz1BnN+k9ObpvS0eIBblPMp2YWL8FBmi9qblQ9fexc2k/CXFgrTIteU3jAw3payCnwSTA==",
+          "dev": true,
+          "requires": {
+            "astral-regex": "^1.0.0",
+            "strip-ansi": "^5.2.0"
+          }
         },
         "supports-color": {
           "version": "7.1.0",
@@ -8668,10 +9372,14 @@
       "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
     },
     "object-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
-      "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ==",
-      "optional": true
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
+      "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+      "optional": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
     },
     "object-keys": {
       "version": "1.1.1",
@@ -8786,17 +9494,6 @@
         "log-symbols": "^2.2.0",
         "strip-ansi": "^5.2.0",
         "wcwidth": "^1.0.1"
-      },
-      "dependencies": {
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        }
       }
     },
     "os-tmpdir": {
@@ -9046,6 +9743,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "promise-polyfill": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
+      "integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==",
       "dev": true
     },
     "prompts": {
@@ -9308,6 +10011,17 @@
         "uuid": "^3.3.2"
       },
       "dependencies": {
+        "form-data": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
         "punycode": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -9383,9 +10097,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
-      "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.16.0.tgz",
+      "integrity": "sha512-LarL/PIKJvc09k1jaeT4kQb/8/7P+qV4qSnN2K80AES+OHdfZELAKVOBjxsvtToT/uLOfFbvYvKfZmV8cee7nA==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -10113,22 +10827,27 @@
       "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
     },
     "string-length": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-length/-/string-length-3.1.0.tgz",
-      "integrity": "sha512-Ttp5YvkGm5v9Ijagtaz1BnN+k9ObpvS0eIBblPMp2YWL8FBmi9qblQ9fexc2k/CXFgrTIteU3jAw3payCnwSTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
+      "integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
       "dev": true,
       "requires": {
-        "astral-regex": "^1.0.0",
-        "strip-ansi": "^5.2.0"
+        "strip-ansi": "^3.0.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
         "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "^2.0.0"
           }
         }
       }
@@ -10142,12 +10861,35 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.0.tgz",
-      "integrity": "sha512-EEJnGqa/xNfIg05SxiPSqRS7S9qwDhYts1TSLR1BQfYUfPe1stofgGKvwERK9+9yf+PpfBMlpBaCHucXGPQfUA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -10174,9 +10916,9 @@
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.0.tgz",
-      "integrity": "sha512-iCP8g01NFYiiBOnwG1Xc3WZLyoo+RuBymwIlWncShXDDJYWN6DbnM3odslBJdgCdRlq94B5s63NWAZlcn2CS4w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -10191,20 +10933,12 @@
       }
     },
     "strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
       "dev": true,
       "requires": {
-        "ansi-regex": "^5.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
-        }
+        "ansi-regex": "^4.1.0"
       }
     },
     "strip-bom": {
@@ -10236,6 +10970,56 @@
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls=",
       "optional": true
+    },
+    "superagent": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+      "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "^1.2.0",
+        "cookiejar": "^2.1.0",
+        "debug": "^3.1.0",
+        "extend": "^3.0.0",
+        "form-data": "^2.3.1",
+        "formidable": "^1.2.0",
+        "methods": "^1.1.1",
+        "mime": "^1.4.1",
+        "qs": "^6.5.1",
+        "readable-stream": "^2.3.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        }
+      }
     },
     "superstatic": {
       "version": "6.0.4",
@@ -10349,15 +11133,6 @@
           "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
           "dev": true
         },
-        "string-length": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
-          "integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
-          "dev": true,
-          "requires": {
-            "strip-ansi": "^3.0.0"
-          }
-        },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -10373,6 +11148,16 @@
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
+      }
+    },
+    "supertest": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-4.0.2.tgz",
+      "integrity": "sha512-1BAbvrOZsGA3YTCWqbmh14L0YEq0EGICX/nBnfkfVJn7SrxQV1I3pMYjSzG9y/7ZU2V9dWqyqk2POwxlb09duQ==",
+      "dev": true,
+      "requires": {
+        "methods": "^1.1.2",
+        "superagent": "^3.8.3"
       }
     },
     "supports-color": {
@@ -10538,12 +11323,6 @@
             "signal-exit": "^3.0.0",
             "strip-eof": "^1.0.0"
           }
-        },
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-          "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
@@ -10772,9 +11551,9 @@
       "dev": true
     },
     "ts-jest": {
-      "version": "25.3.1",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-25.3.1.tgz",
-      "integrity": "sha512-O53FtKguoMUByalAJW+NWEv7c4tus5ckmhfa7/V0jBb2z8v5rDSLFC1Ate7wLknYPC1euuhY6eJjQq4FtOZrkg==",
+      "version": "25.4.0",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-25.4.0.tgz",
+      "integrity": "sha512-+0ZrksdaquxGUBwSdTIcdX7VXdwLIlSRsyjivVA9gcO+Cvr6ByqDhu/mi5+HCcb6cMkiQp5xZ8qRO7/eCqLeyw==",
       "dev": true,
       "requires": {
         "bs-logger": "0.x",
@@ -11065,12 +11844,6 @@
         "xdg-basedir": "^3.0.0"
       },
       "dependencies": {
-        "ci-info": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-          "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
-          "dev": true
-        },
         "configstore": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
@@ -11098,15 +11871,6 @@
           "dev": true,
           "requires": {
             "is-obj": "^1.0.0"
-          }
-        },
-        "is-ci": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
-          "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
-          "dev": true,
-          "requires": {
-            "ci-info": "^1.5.0"
           }
         },
         "is-obj": {
@@ -11334,6 +12098,12 @@
         "iconv-lite": "0.4.24"
       }
     },
+    "whatwg-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
+      "dev": true
+    },
     "whatwg-mimetype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
@@ -11418,12 +12188,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "string-width": {
@@ -11516,6 +12280,12 @@
         "strip-ansi": "^6.0.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
         "ansi-styles": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
@@ -11540,6 +12310,15 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
         }
       }
     },
@@ -11602,6 +12381,12 @@
       "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
       "dev": true
     },
+    "xmlhttprequest": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
+      "dev": true
+    },
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -11638,9 +12423,9 @@
       }
     },
     "yargs-parser": {
-      "version": "18.1.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.2.tgz",
-      "integrity": "sha512-hlIPNR3IzC1YuL1c2UwwDKpXlNFBqD1Fswwh1khz5+d8Cq/8yc/Mn0i+rQXduu8hcrFKvO7Eryk+09NecTQAAQ==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",

--- a/functions/package.json
+++ b/functions/package.json
@@ -6,8 +6,10 @@
     "serve": "npm run build && GOOGLE_APPLICATION_CREDENTIALS=key.json firebase serve",
     "shell": "npm run build && firebase functions:shell",
     "start": "npm run serve",
-    "test": "jest",
-    "test:watch": "jest --watch",
+    "firestore-emulator": "firebase emulators:start --only firestore",
+    "test": "FIRESTORE_EMULATOR_HOST=localhost:8999 jest --detectOpenHandles",
+    "test:with-emulator": "firebase emulators:exec --only firestore \"npm run test\"",
+    "test:watch": "FIRESTORE_EMULATOR_HOST=localhost:8999 jest --watch",
     "deploy": "firebase use --clear && firebase deploy",
     "deploy:staging": "firebase deploy --project staging",
     "logs": "firebase functions:log"
@@ -26,11 +28,14 @@
     "jsonwebtoken": "^8.5.1"
   },
   "devDependencies": {
+    "@firebase/testing": "^0.19.1",
     "@types/jest": "^24.0.18",
     "@types/jsonwebtoken": "^8.3.4",
+    "@types/supertest": "^2.0.8",
     "firebase-functions-test": "^0.2.1",
-    "firebase-tools": "^8.0.2",
+    "firebase-tools": "^8.1.0",
     "jest": "^25.3.0",
+    "supertest": "^4.0.2",
     "ts-jest": "^25.3.1",
     "tslint": "^6.1.1",
     "typescript": "^3.8.3"
@@ -57,6 +62,11 @@
       "ts-jest": {
         "diagnostics": false
       }
-    }
+    },
+    "testPathIgnorePatterns": [
+      "lib/",
+      "node_modules/"
+    ],
+    "testEnvironment": "node"
   }
 }

--- a/functions/package.json
+++ b/functions/package.json
@@ -9,7 +9,7 @@
     "firestore-emulator": "firebase emulators:start --only firestore",
     "test": "FIRESTORE_EMULATOR_HOST=localhost:8999 jest --detectOpenHandles",
     "test:with-emulator": "firebase emulators:exec --only firestore \"npm run test\"",
-    "test:watch": "FIRESTORE_EMULATOR_HOST=localhost:8999 jest --watch",
+    "test:watch": "FIRESTORE_EMULATOR_HOST=localhost:8999 jest --watch --detectOpenHandles",
     "deploy": "firebase use --clear && firebase deploy",
     "deploy:staging": "firebase deploy --project staging",
     "logs": "firebase functions:log"

--- a/functions/src/index.test.ts
+++ b/functions/src/index.test.ts
@@ -1,0 +1,53 @@
+// @firebase/testing module is used to interact with the emulator that runs locally.
+// It's mostly described in the context of Firestore rules testing: https://firebase.google.com/docs/rules/unit-tests
+const firebaseTesting = require("@firebase/testing");
+const functions = require("firebase-functions-test");
+const supertest = require("supertest");
+// This is necessary automatically setup config for test environment.
+// If you want to connect to real Firestore, configuration can be provided here.
+// Otherwise, emulator is needed. Emulator is set using env variable: FIRESTORE_EMULATOR_HOST
+// (check package.json scripts).
+const projectId = "test-project";
+const firebaseFunctionsEnv = functions({ projectId });
+// Require functions AFTER calling functions.
+const { webApiV1, db } = require("./index");
+
+const checkResponse = (response: any) => {
+  const json = JSON.parse(response.text);
+  expect(json.status).toEqual("success");
+  return json;
+}
+
+describe("token-service app", () => {
+  afterAll(async () => {
+    await firebaseFunctionsEnv.cleanup();
+  });
+  beforeEach(async () => {
+    await firebaseTesting.clearFirestoreData({ projectId });
+  });
+
+  it("GET api/v1/test", async () => {
+    const response = await supertest(webApiV1)
+      .get("/api/v1/test")
+      .query({ env: "dev" })
+      .expect(200);
+    const json = checkResponse(response);
+    expect(json.result).toEqual("test OK");
+  });
+
+  it("POST api/v1/test", async () => {
+    const testEntries = await db.collection("test").get();
+    // Ensure that we're dealing with EMPTY firestore db.
+    expect(testEntries.size).toEqual(0);
+    const content = { content: "TEST CONTENT" + Date.now() };
+    const response = await supertest(webApiV1)
+      .post("/api/v1/test")
+      .query({ env: "dev" })
+      .send(content)
+      .expect(200);
+    const json = checkResponse(response);
+    expect(json.result).toEqual("test write OK");
+    const doc = await db.collection("test").doc("test-doc").get();
+    expect(doc.data()).toEqual(content);
+  });
+});

--- a/functions/src/index.test.ts
+++ b/functions/src/index.test.ts
@@ -1,14 +1,15 @@
 // @firebase/testing module is used to interact with the emulator that runs locally.
 // It's mostly described in the context of Firestore rules testing: https://firebase.google.com/docs/rules/unit-tests
 import * as firebaseTesting from "@firebase/testing";
-import * as functions from "firebase-functions-test";
+import * as firebaseFunctionsTest from "firebase-functions-test";
 // This is necessary automatically setup config for test environment.
 // If you want to connect to real Firestore, configuration can be provided here.
 // Otherwise, emulator is needed. Emulator is set using env variable: FIRESTORE_EMULATOR_HOST
 // (check package.json scripts).
 const projectId = "test-project";
-const firebaseFunctionsEnv = functions({ projectId });
-// Require functions AFTER calling functions.
+const firebaseFunctionsEnv = firebaseFunctionsTest({ projectId });
+// Require ./index AFTER calling firebaseFunctionsTest.
+// firebaseFunctionsTest mocks firebase.config() that is used in the ./index module.
 import { webApiV1, db } from "./index";
 
 import * as supertest from "supertest";

--- a/functions/src/index.test.ts
+++ b/functions/src/index.test.ts
@@ -1,8 +1,7 @@
 // @firebase/testing module is used to interact with the emulator that runs locally.
 // It's mostly described in the context of Firestore rules testing: https://firebase.google.com/docs/rules/unit-tests
-const firebaseTesting = require("@firebase/testing");
-const functions = require("firebase-functions-test");
-const supertest = require("supertest");
+import * as firebaseTesting from "@firebase/testing";
+import * as functions from "firebase-functions-test";
 // This is necessary automatically setup config for test environment.
 // If you want to connect to real Firestore, configuration can be provided here.
 // Otherwise, emulator is needed. Emulator is set using env variable: FIRESTORE_EMULATOR_HOST
@@ -10,13 +9,47 @@ const supertest = require("supertest");
 const projectId = "test-project";
 const firebaseFunctionsEnv = functions({ projectId });
 // Require functions AFTER calling functions.
-const { webApiV1, db } = require("./index");
+import { webApiV1, db } from "./index";
+
+import * as supertest from "supertest";
+import { FireStoreS3Resource, FireStoreS3ResourceSettings } from "./firestore-types";
+import { ReadWriteTokenPrefix } from "./resource-types";
 
 const checkResponse = (response: any) => {
   const json = JSON.parse(response.text);
   expect(json.status).toEqual("success");
   return json;
 }
+
+const defS3Settings: FireStoreS3ResourceSettings = {
+  type: "s3Folder",
+  tool: "test-tool",
+  bucket: "test-bucket",
+  region: "test-region",
+  folder: "test-folder",
+  allowedAccessRuleTypes: ["user", "context", "readWriteToken"]
+};
+const readWriteToken = ReadWriteTokenPrefix + "123xyz";
+
+const createS3Settings = async (customSettings?: FireStoreS3ResourceSettings) => {
+  const finalSettings = Object.assign({}, defS3Settings, customSettings);
+  await db.collection("dev:resourceSettings").doc("settings-id-1").set(finalSettings);
+  return finalSettings;
+};
+const createS3Resource = async (customSettings?: FireStoreS3Resource) => {
+  const resource: FireStoreS3Resource = {
+    type: defS3Settings.type,
+    tool: defS3Settings.tool,
+    description: "test-description",
+    accessRules: [
+      {type: "user", role: "owner", platformId: "test", userId: "test-user"},
+      {type: "readWriteToken", readWriteToken}
+    ],
+    name: "test.txt"
+  };
+  const ref = await db.collection("dev:resources").add(Object.assign(resource, customSettings));
+  return Object.assign({ id: ref.id }, resource);
+};
 
 describe("token-service app", () => {
   afterAll(async () => {
@@ -49,5 +82,56 @@ describe("token-service app", () => {
     expect(json.result).toEqual("test write OK");
     const doc = await db.collection("test").doc("test-doc").get();
     expect(doc.data()).toEqual(content);
+  });
+
+  describe("GET api/v1/resource", () => {
+    it("returns resource without accessRules when run anonymously", async () => {
+      const settings = await createS3Settings();
+      const resource = await createS3Resource();
+      const response = await supertest(webApiV1)
+        .get("/api/v1/resources/" + resource.id)
+        .query({ env: "dev" })
+        .expect(200);
+
+      const json = checkResponse(response);
+      expect(json.result).toEqual({
+        id: resource.id,
+        name: resource.name,
+        description: resource.description,
+        publicPath: `test-folder/${resource.id}/`,
+        publicUrl: `https://test-bucket.s3.amazonaws.com/test-folder/${resource.id}/`,
+        bucket: settings.bucket,
+        folder: settings.folder,
+        region: settings.region,
+        tool: settings.tool,
+        type: settings.type
+        // no access rules
+      });
+    });
+
+    it("returns resource with accessRules when user is authenticated (readWriteToken)", async () => {
+      const settings = await createS3Settings();
+      const resource = await createS3Resource();
+      const response = await supertest(webApiV1)
+        .get("/api/v1/resources/" + resource.id)
+        .set("Authorization", `Bearer ${readWriteToken}`)
+        .query({ env: "dev" })
+        .expect(200);
+
+      const json = checkResponse(response);
+      expect(json.result).toEqual({
+        id: resource.id,
+        name: resource.name,
+        description: resource.description,
+        publicPath: `test-folder/${resource.id}/`,
+        publicUrl: `https://test-bucket.s3.amazonaws.com/test-folder/${resource.id}/`,
+        bucket: settings.bucket,
+        folder: settings.folder,
+        region: settings.region,
+        tool: settings.tool,
+        type: settings.type,
+        accessRules: resource.accessRules // !!!
+      });
+    });
   });
 });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -27,7 +27,7 @@ admin.initializeApp(functions.config().firebase);
 admin.firestore().settings({
   timestampsInSnapshots: true   // this removes a deprecation warning
 });
-const db = admin.firestore();
+export const db = admin.firestore();
 
 const app = express();
 
@@ -177,6 +177,16 @@ app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cors());
 app.use(checkEnv);
+
+app.get('/api/v1/test', (req, res) => {
+  res.success("test OK");
+});
+
+app.post('/api/v1/test', (req, res) => {
+  db.collection("test").doc("test-doc").set(req.body)
+    .then(writeResult => res.success("test write OK"))
+    .catch(error => res.error(400, error));
+});
 
 app.get('/api/v1/resources', (req, res) => {
   // Use caching here to avoid hitting Firestore db for every resource that is being returned.

--- a/functions/src/resource-types.ts
+++ b/functions/src/resource-types.ts
@@ -45,15 +45,14 @@ export interface FindAllQuery {
 }
 
 // mark all resource fields as optional so we get type checking
-export type ResourceQuery = Omit<Partial<Resource>, "id">;
-export type S3ResourceQuery = Omit<Partial<S3Resource>, "id">;
+export type ResourceQuery = Omit<Resource, "id">;
 
 export interface CreateQuery extends ResourceQuery {
   accessRuleType: AccessRuleType;
   accessRuleRole?: AccessRuleRole;
 }
 
-export type UpdateQuery = Omit<Omit<ResourceQuery, 'type'>, 'tool'>;
+export type UpdateQuery = Partial<Omit<ResourceQuery, 'type' | 'tool'>>;
 
 export interface Credentials {
   accessKeyId: string;

--- a/functions/tslint.json
+++ b/functions/tslint.json
@@ -54,7 +54,7 @@
 
     // Do not allow any imports for modules that are not in package.json. These will almost certainly fail when
     // deployed.
-    "no-implicit-dependencies": true,
+    "no-implicit-dependencies": [true, "dev"],
 
     // The 'this' keyword can only be used inside of classes.
     "no-invalid-this": true,


### PR DESCRIPTION
[#172226773]

This PR includes only setup and test tests ;) that shows what kind of testing I'm planning to implement. Stubbing Firestore could work too, but this kind of tests should cover more and might be easier to write. It's pretty much an end-to-end test of the API. Firestore emulator works reasonably fast.

I've added fake path `api/v1/test`, as it was easier to use that to test initial setup. I can remove them later although, they might be useful for debugging if we want e.g. to check to test using real firestore.

If someone setups similar thing in the near future:
`"testEnvironment": "node"` line in package.json is critical. There's some conflict between jest nad firebase-admin packages. Without that, firebase fails providing only some unclear errors (`TypeError: The "path" argument must be of type string. Received an instance of ObjectTypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received an instance of Object`).