### PR TITLE
Update example-app, refactor and provide update file example

### DIFF
--- a/example-app/src/helpers.ts
+++ b/example-app/src/helpers.ts
@@ -39,56 +39,37 @@ export const getFirebaseJwt = (portalUrl: string, portalAccessToken: string, fir
     .then(json => json.token)
 };
 
-export const uploadFileUsingFirebaseJWT = async (filename: string, fileContent: string, firebaseJwt: string, tokenServiceEnv: "dev" | "staging") => {
-  // If JWT is provided in the constructor, it'll be used in all the following requests to token-service server.
-  const client = new TokenServiceClient({ jwt: firebaseJwt, env: tokenServiceEnv });
+interface ICreateFile {
+  filename: string;
+  fileContent: string;
+  firebaseJwt?: string;
+  tokenServiceEnv: "dev" | "staging";
+}
+export const createFile = async ({ filename, fileContent, firebaseJwt, tokenServiceEnv }: ICreateFile) => {
+  // This function optionally accepts firebaseJWT. There are three things that depend on authentication method:
+  // - TokenServiceClient constructor arguments. If user should be authenticated during every call to the API, provide `jwt` param.
+  // - createResource call. If user is not authenticated, "readWriteToken" accessRule type must be used. Token Service will generate and return readWriteToken.
+  // - getCredentials call. If user is not authenticated, readWriteToken needs to be provided instead.
+  const anonymous = !firebaseJwt;
+
+  const client = anonymous ? new TokenServiceClient({ env: tokenServiceEnv }) : new TokenServiceClient({ env: tokenServiceEnv, jwt: firebaseJwt })
   const resource: S3Resource = await client.createResource({
     tool: "example-app",
     type: "s3Folder",
-    name: filename,
+    name: "test file" + filename,
     description: "test file",
-    accessRuleType: "user"
-  }) as S3Resource;
-  console.log("new resource:", resource);
-
-  const credentials = await client.getCredentials(resource.id);
-  console.log("credentials:", credentials);
-
-  // S3 configuration is based both on resource and credentials info.
-  const { bucket, region } = resource;
-  const { accessKeyId, secretAccessKey, sessionToken } = credentials;
-  const s3 = new AWS.S3({ region, accessKeyId, secretAccessKey, sessionToken });
-  const publicPath = client.getPublicS3Path(resource, filename);
-
-  const result = await s3.upload({
-    Bucket: bucket,
-    Key: publicPath,
-    Body: fileContent,
-    ContentType: "text/html",
-    ContentEncoding: "UTF-8",
-    CacheControl: "no-cache"
-  }).promise();
-  console.log(result);
-
-  return client.getPublicS3Url(resource, filename);
-};
-
-export const uploadFileAnonymously = async (filename: string, fileContent: string, tokenServiceEnv: "dev" | "staging") => {
-  const client = new TokenServiceClient({ env: tokenServiceEnv });
-  const resource: S3Resource = await client.createResource({
-    tool: "example-app",
-    type: "s3Folder",
-    name: filename,
-    description: "test file",
-    accessRuleType: "readWriteToken"
+    accessRuleType: anonymous ? "readWriteToken" : "user"
   }) as S3Resource;
   console.log("new resource:", resource);
 
   // Note that if your file ever needs to get updated, this token MUST BE (SECURELY) SAVED.
-  const readWriteToken = client.getReadWriteToken(resource);
-  console.log("read write token:", readWriteToken);
+  let readWriteToken = "";
+  if (anonymous) {
+    readWriteToken = client.getReadWriteToken(resource) || "";
+    console.log("read write token:", readWriteToken);
+  }
 
-  const credentials = await client.getCredentials(resource.id, readWriteToken);
+  const credentials = anonymous ? await client.getCredentials(resource.id, readWriteToken) :  await client.getCredentials(resource.id);
   console.log("credentials:", credentials);
 
   // S3 configuration is based both on resource and credentials info.
@@ -107,7 +88,49 @@ export const uploadFileAnonymously = async (filename: string, fileContent: strin
   }).promise();
   console.log(result);
 
-  return client.getPublicS3Url(resource, filename);
+  return {
+    publicUrl: client.getPublicS3Url(resource, filename),
+    resourceId: resource.id,
+    readWriteToken
+  };
+};
+
+interface IUpdateFileArgs {
+  filename: string;
+  newFileContent: string;
+  resourceId: string;
+  firebaseJwt?: string;
+  readWriteToken?: string;
+  tokenServiceEnv: "dev" | "staging";
+}
+export const updateFile = async ({ filename, newFileContent, resourceId, firebaseJwt, readWriteToken, tokenServiceEnv}: IUpdateFileArgs) => {
+  // This function accepts either firebaseJWT or readWriteToken. There are only two things that depend on authentication method:
+  // - TokenServiceClient constructor arguments. If user should be authenticated during every call to the API, provide `jwt` param.
+  // - getCredentials call. If user is not authenticated, readWriteToken needs to be provided instead.
+  const anonymous = !firebaseJwt && readWriteToken;
+
+  const client = anonymous ? new TokenServiceClient({ env: tokenServiceEnv }) : new TokenServiceClient({ env: tokenServiceEnv, jwt: firebaseJwt })
+  const resource: S3Resource = await client.getResource(resourceId) as S3Resource;
+  console.log("get resource:", resource);
+
+  const credentials = anonymous ? await client.getCredentials(resource.id, readWriteToken) : await client.getCredentials(resource.id);
+  console.log("credentials:", credentials);
+
+  // S3 configuration is based both on resource and credentials info.
+  const { bucket, region } = resource;
+  const { accessKeyId, secretAccessKey, sessionToken } = credentials;
+  const s3 = new AWS.S3({ region, accessKeyId, secretAccessKey, sessionToken });
+  const publicPath = client.getPublicS3Path(resource, filename);
+
+  const result = await s3.upload({
+    Bucket: bucket,
+    Key: publicPath,
+    Body: newFileContent,
+    ContentType: "text/html",
+    ContentEncoding: "UTF-8",
+    CacheControl: "no-cache"
+  }).promise();
+  console.log(result);
 };
 
 export const logAllResources = async (firebaseJwt: string, amOwner: boolean, tokenServiceEnv: "dev" | "staging") => {

--- a/example-app/src/index.html
+++ b/example-app/src/index.html
@@ -16,6 +16,8 @@
       }
       #app {
         padding: 10px;
+        word-wrap: break-word;
+        overflow-wrap: break-word;
       }
       button {
         font-size: 17px;
@@ -29,12 +31,16 @@
       }
       textarea {
         width: 600px;
-        height: 80px;
+        height: 40px;
       }
       .section {
         border: 1px solid gray;
         padding: 10px;
         margin: 5px;
+      }
+      .disabled {
+        pointer-events: none;
+        opacity: 0.5;
       }
       .hint {
         font-size: 0.85em;


### PR DESCRIPTION
Demo:
http://token-service.concord.org/branch/update-example/example-app/index.html
(note that if you use learn.staging, you won't be able to authenticate as this URL is not registered as a valid redirect URL. But readWriteToken path should work).

@scytacki, you suggested creating a separate page, but I kept everything together. I think this new layout explains why. Basically, we can't update file without having all the info obtained before. I've also reorganized fields a bit and disabled buttons based on the available data, so it's more clear what can be done when.

I also refactored helpers, merged together anonymous functions with ones that use firebaseJWT, and tried to show differences clearly (+ added some comments about that). They're almost the same, so I didn't want o to create 2 more functions that have only 2/3 different lines.

I could also merge together `createFile` and `updateFile` functions, as the only difference is `getResource` vs `createResource` at the very beginning. Or extract s3 upload part to separate helper. But I decided to keep it like that, so it's easier to read when someone wants to quickly check how to create or update file (without having to parse the function body in mind or jump between helper functions). 