### PR TITLE
Add domainIncludesFolder option

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ The entry should look like this:
   tool: "example-app",
   type: "s3Folder",
   allowedAccessRuleTypes: ["user", "context"], // optionally "readWriteToken", check AccessRuleType type for all allowed values
-  domain: "https://cloudfront.domain.com" // optionally domain that will be used to construct public URL, usually a cloudfront domain
+  domain: "https://cloudfront.domain.com", // optionally domain that will be used to construct public URL, usually a cloudfront domain
+  domainIncludesFolder: true // optional, but it needs to be set when the domain points to S3 bucket folder, not just the root. It prevents token-service from appending folder to the path and URL again.
 ```
 
 ## Development Setup

--- a/functions/src/base-resource-object.test.ts
+++ b/functions/src/base-resource-object.test.ts
@@ -254,6 +254,24 @@ describe("Resource", () => {
           publicUrl: "https://cloudfront.domain.com/test-folder/test/"
         });
       });
+
+      it("should return custom public path based on bucket when settings include domain and domainIncludesFolder=true", () => {
+        expect(createS3Resource().apiResult(
+          undefined,
+          {bucket: "test-bucket", folder: "test-folder", region: "test-region", domain: "https://cloudfront.domain.with-folder.com", domainIncludesFolder: true} as FireStoreResourceSettings)
+        ).toEqual({
+          id: "test",
+          name: "test",
+          description: "test",
+          type: "s3Folder",
+          tool: "glossary",
+          bucket: "test-bucket",
+          folder: "test-folder",
+          region: "test-region",
+          publicPath: "test/",
+          publicUrl: "https://cloudfront.domain.with-folder.com/test/"
+        });
+      });
     });
 
     it("should be capable of creating vortex configurations", () => {

--- a/functions/src/base-resource-object.ts
+++ b/functions/src/base-resource-object.ts
@@ -338,6 +338,10 @@ export class BaseResourceObject implements BaseResource {
 export class S3ResourceObject extends BaseResourceObject {
   getPublicPath(settings: FireStoreS3ResourceSettings) {
     const { id } = this;
+    // Domain can point to the S3 bucket root or it can include folder path.
+    if (settings.domain && settings.domainIncludesFolder) {
+      return `${id}/`;
+    }
     return `${settings.folder}/${id}/`;
   }
 

--- a/functions/src/firestore-types.ts
+++ b/functions/src/firestore-types.ts
@@ -32,6 +32,11 @@ export interface FireStoreS3ResourceSettings extends ResourceSettings {
   region: string;
   // Optional domain, usually pointing to cloudfront distribution. It affects publicUrl of the resource.
   domain?: string;
+  // Domain can point to the S3 bucket root or it can include folder path. For example:
+  // 1. https://models-resources.concord.org -> https://models-resources.s3.amazonaws.com
+  // 2. https://cfm-shared.concord.org -> https://models-resources.s3.amazonaws.com/cfm-shared
+  // 1. domain would require this option undefined or equal to false, while 2. requires it set to true.
+  domainIncludesFolder?: boolean;
 }
 
 export interface FirestoreIotOrganizationSettings extends ResourceSettings {


### PR DESCRIPTION
[#173770179]

Scott set https://cfm-shared.concord.org to point to models-resources/cfm-shared bucket/folder. token-service didn't support this case before and it was always adding the folder to the path.