### PR TITLE
Fix handling of domainIncludesFolder option

### DIFF
--- a/functions/src/base-resource-object.test.ts
+++ b/functions/src/base-resource-object.test.ts
@@ -268,7 +268,7 @@ describe("Resource", () => {
           bucket: "test-bucket",
           folder: "test-folder",
           region: "test-region",
-          publicPath: "test/",
+          publicPath: "test-folder/test/",
           publicUrl: "https://cloudfront.domain.with-folder.com/test/"
         });
       });

--- a/functions/src/base-resource-object.ts
+++ b/functions/src/base-resource-object.ts
@@ -338,14 +338,15 @@ export class BaseResourceObject implements BaseResource {
 export class S3ResourceObject extends BaseResourceObject {
   getPublicPath(settings: FireStoreS3ResourceSettings) {
     const { id } = this;
-    // Domain can point to the S3 bucket root or it can include folder path.
-    if (settings.domain && settings.domainIncludesFolder) {
-      return `${id}/`;
-    }
     return `${settings.folder}/${id}/`;
   }
 
   getPublicUrl(settings: FireStoreS3ResourceSettings) {
+    // Domain can point to the S3 bucket root or it can include folder path.
+    if (settings.domain && settings.domainIncludesFolder) {
+      const { id } = this;
+      return `${settings.domain}/${id}/`;
+    }
     if (settings.domain) {
       return `${settings.domain}/${this.getPublicPath(settings)}`;
     }


### PR DESCRIPTION
[#173770179]

Previous implementation was breaking apps that use `publicPath` during S3 upload. E.g. CFM was using it that way, so S3 upload was failing. So, let's limit `domainIncludesFolder` only to places where the domain is actually used - full URLs. I guess it makes sense to leave publicPath unaffected, as it can be used by client apps to manually construct URL without referring to the custom domain.
