### PR TITLE
Example App: add delete file example

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ app. Its build process can also be run directly from example-app dir using `npm 
 
 To start local server with example app:
 
-1. `cd functions` (all the commands below should be executed in `example-app/` dir)
+1. `cd example-app` (all the commands below should be executed in `example-app/` dir)
 2. Install dependencies: `npm i`
 3. Start local server: `npm start`
 

--- a/example-app/src/index.tsx
+++ b/example-app/src/index.tsx
@@ -74,6 +74,16 @@ const AppComponent = () => {
     alert("Done! Open the file again.");
   };
 
+  const handleDeleteFileUsingJWT = async () => {
+    await helpers.deleteFile({ filename, resourceId, firebaseJwt, tokenServiceEnv });
+    alert("Done! Try to open the file again - you should see 404 Not Found.");
+  };
+
+  const handleDeleteFileAnonymously = async () => {
+    await helpers.deleteFile({ filename, resourceId, readWriteToken, tokenServiceEnv });
+    alert("Done! Try to open the file again -  you should see 404 Not Found.");
+  };
+
   const handleLogAllMyResources = () => {
     helpers.logAllResources(firebaseJwt, true, tokenServiceEnv as "dev" | "staging");
   };
@@ -148,6 +158,16 @@ const AppComponent = () => {
         </p>
         <p>
           <button onClick={handleUpdateFileAnonymously} disabled={!readWriteToken}>Update using readWriteToken</button>
+        </p>
+      </div>
+
+      <div className={`section ${resourceId ? "" : "disabled"}`}>
+        <h3>Delete File</h3>
+        <p>
+          <button onClick={handleDeleteFileUsingJWT} disabled={!firebaseJwt || !!readWriteToken}>Delete using Firebase JWT (File needs to be created using JWT)</button>
+        </p>
+        <p>
+          <button onClick={handleDeleteFileAnonymously} disabled={!readWriteToken}>Delete using readWriteToken</button>
         </p>
       </div>
 


### PR DESCRIPTION
[#174012764]

@scytacki, the policy defined in functions codebase:
https://github.com/concord-consortium/token-service/blob/master/functions/src/base-resource-object.ts#L389-L418
was already listing delete actions, so no changes and new deployment were necessary there.

However, delete action wasn't working anyway. I had to update the policy attached to token-service-staging IAM role:
https://console.aws.amazon.com/iam/home?region=us-east-1#/roles/token-service-staging (ConcordQA)
using AWS UI. It fixed the delete action.

So, I went ahead and also did the same for production role:
https://console.aws.amazon.com/iam/home?region=us-east-1#/roles/token-service-production

If you open the demo page:
http://token-service.concord.org/branch/delete-file/example-app/index.html
you can create a new file, update, delete, and then update again (there's little delay between delete and update, it seems 404 is cached for a bit). So, that should cover everything that CFM needs.

I didn't work on the commit hash and file filters, as it's a bit separate task (no changes to functions this time), and I'd like to get CFM fixed asap. But I've added a story that I can come back to later: https://www.pivotaltracker.com/story/show/174197199
