### PR TITLE
Add Athena Workgroup Resource

### DIFF
--- a/example-app/src/athena-demo.tsx
+++ b/example-app/src/athena-demo.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from "react";
+import * as helpers from "./helpers";
+import { Section, useInput } from "./form";
+import { AthenaResource, EnvironmentName, ResourceType, Credentials } from "@concord-consortium/token-service";
+import * as AWS from "aws-sdk";
+
+interface AthenaDemoProps {
+  credentials?: Credentials;
+  athenaResource?: AthenaResource;
+}
+
+export const AthenaDemo : React.FunctionComponent<AthenaDemoProps> = props => {
+  const [queries, setQueries] = useState<string[] | undefined>();
+
+  const {credentials, athenaResource} = props;
+
+  const handleListQueryExecutions = async () => {
+    if (!credentials || !athenaResource) return;
+    const { region } = athenaResource;
+    const { accessKeyId, secretAccessKey, sessionToken } = credentials;
+    const athena = new AWS.Athena({ region, accessKeyId, secretAccessKey, sessionToken });
+
+    const results = await athena.listQueryExecutions({
+      WorkGroup: `${athenaResource.name}-${athenaResource.id}`
+    }).promise();
+
+    setQueries(results.QueryExecutionIds);
+  };
+
+  return <Section title="Athena API Demo" disabled={!credentials || !athenaResource}>
+    <p>A AthenaResource and Credentials are required</p>
+    <Section title="List Queries">
+      <p>
+        <button onClick={handleListQueryExecutions}>List Queries</button>
+      </p>
+      { queries ?
+          <ul>
+            { queries.map(query =>
+              <li key={query}>{query}</li>
+            )}
+          </ul>
+        :
+          <p>click button to load queries</p>
+      }
+    </Section>
+  </Section>;
+}

--- a/example-app/src/index.tsx
+++ b/example-app/src/index.tsx
@@ -2,8 +2,9 @@ import React, { useEffect, useState, ChangeEvent } from "react";
 import ReactDOM from "react-dom";
 import * as helpers from "./helpers";
 import { Section, useLocalStorageInput, useInput} from "./form";
-import { Resource, S3Resource, EnvironmentName, ResourceType, Credentials } from "@concord-consortium/token-service";
+import { Resource, S3Resource, AthenaResource, EnvironmentName, ResourceType, Credentials } from "@concord-consortium/token-service";
 import { S3Demo } from "./s3-demo";
+import { AthenaDemo } from "./athena-demo";
 
 type ResourceMap = {[key: string]: Resource};
 
@@ -128,6 +129,7 @@ const AppComponent = () => {
         </p>
         <p>Resource Type: <select {...resourceTypeProps} >
           <option value="s3Folder">s3Folder</option>
+          <option value="athenaWorkgroup">athenaWorkgroup</option>
           <option value="iotOrganization">iotOrganization</option>
         </select></p>
       </Section>
@@ -204,6 +206,10 @@ const AppComponent = () => {
 
       { resourceType === "s3Folder" &&
         <S3Demo credentials={credentials} s3Resource={currentResource as S3Resource} />
+      }
+
+      { resourceType === "athenaWorkgroup" &&
+        <AthenaDemo credentials={credentials} athenaResource={currentResource as AthenaResource} />
       }
 
       <Section title="Misc">

--- a/functions/src/firestore-types.ts
+++ b/functions/src/firestore-types.ts
@@ -1,6 +1,6 @@
 import { AccessRuleType, ResourceType, AccessRule } from "./resource-types";
 
-export type FireStoreResource = FireStoreS3Resource | FireStoreIotOrganizationResource;
+export type FireStoreResource = FireStoreS3Resource | FireStoreIotOrganizationResource | FireStoreAthenaWorkgroupResource;
 
 export interface FirestoreBaseResource {
   name: string;
@@ -16,16 +16,19 @@ export interface FireStoreS3Resource extends FirestoreBaseResource {
 export interface FireStoreIotOrganizationResource extends FirestoreBaseResource {
   type: "iotOrganization"
 }
+export interface FireStoreAthenaWorkgroupResource extends FirestoreBaseResource {
+  type: "athenaWorkgroup"
+}
 
-export type FireStoreResourceSettings = FireStoreS3ResourceSettings | FirestoreIotOrganizationSettings;
+export type FireStoreResourceSettings = FireStoreS3ResourceSettings | FireStoreIotOrganizationSettings | FireStoreAthenaWorkgroupSettings;
 
-export interface ResourceSettings {
+interface FireStoreBaseResourceSettings {
   type: ResourceType;
   tool: string;
   allowedAccessRuleTypes: AccessRuleType[];
 }
 
-export interface FireStoreS3ResourceSettings extends ResourceSettings {
+export interface FireStoreS3ResourceSettings extends FireStoreBaseResourceSettings {
   type: "s3Folder";
   bucket: string;
   folder: string;
@@ -39,8 +42,18 @@ export interface FireStoreS3ResourceSettings extends ResourceSettings {
   domainIncludesFolder?: boolean;
 }
 
-export interface FirestoreIotOrganizationSettings extends ResourceSettings {
+export interface FireStoreIotOrganizationSettings extends FireStoreBaseResourceSettings {
   type: "iotOrganization";
+}
+
+export interface FireStoreAthenaWorkgroupSettings extends FireStoreBaseResourceSettings {
+  type: "athenaWorkgroup";
+  // Settings to restrict the s3 access to download the workgroup's files
+  bucket: string;
+  folder: string;
+  region: string;
+  // id of the aws account used in athena workgroup arn
+  account: string;
 }
 
 export interface JWTClaims {

--- a/functions/src/index.test.ts
+++ b/functions/src/index.test.ts
@@ -651,8 +651,6 @@ describe("token-service app", () => {
         .expect(200);
       const json = checkResponse(response);
       expect(json.result).toEqual({
-        bucket: "test-bucket",
-        keyPrefix: `test-folder/${resource.id}/`,
         accessKeyId: fakeAwsCredentials.AccessKeyId,
         secretAccessKey: fakeAwsCredentials.SecretAccessKey,
         sessionToken: fakeAwsCredentials.SessionToken,
@@ -672,8 +670,6 @@ describe("token-service app", () => {
         .expect(200);
       const json = checkResponse(response);
       expect(json.result).toEqual({
-        bucket: "test-bucket",
-        keyPrefix: `test-folder/${resource.id}/`,
         accessKeyId: fakeAwsCredentials.AccessKeyId,
         secretAccessKey: fakeAwsCredentials.SecretAccessKey,
         sessionToken: fakeAwsCredentials.SessionToken,
@@ -705,8 +701,6 @@ describe("token-service app", () => {
         .expect(200);
       const json = checkResponse(response);
       expect(json.result).toEqual({
-        bucket: "test-bucket",
-        keyPrefix: `test-folder/${resource.id}/`,
         accessKeyId: fakeAwsCredentials.AccessKeyId,
         secretAccessKey: fakeAwsCredentials.SecretAccessKey,
         sessionToken: fakeAwsCredentials.SessionToken,

--- a/functions/src/index.test.ts
+++ b/functions/src/index.test.ts
@@ -23,10 +23,8 @@ firebaseFunctionsEnv.mockConfig({
     public_key: testPublicKey
   },
   aws: {
-    s3credentials: {
-      duration: "3600",
-      rolearn: "test-role"
-    },
+    duration: "3600",
+    rolearn: "test-role"
     secret: "aws-secret",
     key: "aws-key"
   }

--- a/functions/src/index.test.ts
+++ b/functions/src/index.test.ts
@@ -24,7 +24,7 @@ firebaseFunctionsEnv.mockConfig({
   },
   aws: {
     duration: "3600",
-    rolearn: "test-role"
+    rolearn: "test-role",
     secret: "aws-secret",
     key: "aws-key"
   }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -75,21 +75,18 @@ const getValidatedConfig = () => {
   if (!config.aws.secret) {
     throw new Error("Missing aws.secret in config!");
   }
-  if (!config.aws.s3credentials) {
-    throw new Error("Missing aws.s3credentials object in config!");
+  if (!config.aws.rolearn) {
+    throw new Error("Missing aws.rolearn in config!");
   }
-  if (!config.aws.s3credentials.rolearn) {
-    throw new Error("Missing aws.s3credentials.rolearn in config!");
-  }
-  if (!config.aws.s3credentials.duration) {
-    throw new Error("Missing aws.s3credentials.duration in config!");
+  if (!config.aws.duration) {
+    throw new Error("Missing aws.duration in config!");
   }
   // configs are stored as strings but we want duration as a number
-  const duration = parseInt(config.aws.s3credentials.duration as unknown as string, 10);
+  const duration = parseInt(config.aws.duration as unknown as string, 10);
   if (isNaN(duration)) {
-    throw new Error("aws.s3credentials.duration is not convertable to an integer!");
+    throw new Error("aws.duration is not convertable to an integer!");
   }
-  config.aws.s3credentials.duration = duration;
+  config.aws.duration = duration;
   return config;
 };
 

--- a/functions/src/models/athena-resource-object.test.ts
+++ b/functions/src/models/athena-resource-object.test.ts
@@ -1,0 +1,142 @@
+import { AthenaResourceObject } from "./athena-resource-object";
+import { AccessRule, ReadWriteTokenAccessRule, ReadWriteTokenPrefix } from "../resource-types";
+import { FireStoreAthenaWorkgroupSettings, JWTClaims, FireStoreResourceSettings } from "../firestore-types";
+import { fakeAwsCredentials, mockAssumeRole } from "../__mocks__/aws-sdk";
+// This should be mocked version
+// import { mockAssumeRole } from "aws-sdk";
+
+const config = {
+  admin: {
+    public_key: "test-public-key"
+  },
+  aws: {
+    key: "test-aws-key",
+    secret: "test-aws-secret",
+    s3credentials: {
+      rolearn: "test-rolearn",
+      duration: 3600
+    }
+  }
+};
+
+const validOwnerAccessRules: AccessRule[] = [
+  {
+    type: "user",
+    role: "owner",
+    platformId: "test-platform-id",
+    userId: "test-user-id"
+  }
+];
+
+const validReadWriteToken1 = ReadWriteTokenPrefix + "test-token-1";
+const validReadWriteToken2 = ReadWriteTokenPrefix + "test-token-2";
+const validReadWriteTokenRules: ReadWriteTokenAccessRule[] = [
+  {
+    type: "readWriteToken",
+    readWriteToken: validReadWriteToken1
+  },
+  {
+    type: "readWriteToken",
+    readWriteToken: validReadWriteToken2
+  }
+];
+
+const invalidClaims: JWTClaims = {
+  platform_id: "invalid-test-platform-id",
+  platform_user_id: "invalid-1",
+  user_id: "invalid-test-user-id"
+};
+const validClaims: JWTClaims = {
+  platform_id: "test-platform-id",
+  platform_user_id: "1",
+  user_id: "test-user-id"
+};
+
+const createAthenaResource = (accessRules: AccessRule[] = [], tool: string = "athena-reports") => {
+  return new AthenaResourceObject("id1234", {
+    name: "test",
+    description: "test",
+    type: "athenaWorkgroup",
+    tool,
+    accessRules
+  });
+};
+
+describe("Resource", () => {
+  describe("AthenaResourceObject", () => {
+    describe("apiResult", () => {
+      it("should return the region in addition to the other standard properties", () => {
+        expect(createAthenaResource().apiResult(
+          undefined,
+          {bucket: "test-bucket", folder: "test-folder", region: "test-region"} as FireStoreResourceSettings)
+        ).toEqual({
+          id: "id1234",
+          name: "test",
+          description: "test",
+          type: "athenaWorkgroup",
+          tool: "athena-reports",
+          region: "test-region",
+          workgroupName: "test-id1234"
+        });
+      });
+    });
+
+    it("should not allow keys to be created without access rules", () => {
+      expect(createAthenaResource([]).canCreateKeys(validClaims)).toEqual(false);
+      expect(createAthenaResource([]).canCreateKeys({ readWriteToken: validReadWriteToken1 })).toEqual(false);
+    });
+
+    it("should not allow keys to be created without valid claims or readWriteToken", () => {
+      expect(createAthenaResource(validOwnerAccessRules).canCreateKeys(invalidClaims)).toEqual(false);
+      expect(createAthenaResource(validReadWriteTokenRules).canCreateKeys({ readWriteToken: "invalid-token" })).toEqual(false);
+    });
+
+    it("should not allow keys to be created with valid readWriteToken", () => {
+      expect(createAthenaResource(validReadWriteTokenRules).canCreateKeys({ readWriteToken: validReadWriteToken1 })).toEqual(false);
+    });
+
+    it("should allow keys to be created with owner claims", () => {
+      expect(createAthenaResource(validOwnerAccessRules).canCreateKeys(validClaims)).toEqual(true);
+    });
+
+    it("should create keys", async () => {
+      const keys = await createAthenaResource().createKeys(config, {bucket: "test-bucket", folder: "test-folder", region: "test-region", account: "12345"} as FireStoreAthenaWorkgroupSettings);
+      expect(keys).toEqual({
+        accessKeyId: fakeAwsCredentials.AccessKeyId,
+        expiration: fakeAwsCredentials.Expiration,
+        secretAccessKey: fakeAwsCredentials.SecretAccessKey,
+        sessionToken: fakeAwsCredentials.SessionToken
+      });
+    });
+    it("should create keys when tool name is long", async () => {
+      // long tool names trigger a different code path which hashes the a string to bring it under a
+      // a STS limit
+      const resource = createAthenaResource([], "really-long-tool-name-no-I-mean-realy-really-long-tool-name");
+      const keys = await resource.createKeys(config, {bucket: "test-bucket", folder: "test-folder", region: "test-region", account: "12345"} as FireStoreAthenaWorkgroupSettings);
+      expect(keys).toEqual({
+        accessKeyId: fakeAwsCredentials.AccessKeyId,
+        expiration: fakeAwsCredentials.Expiration,
+        secretAccessKey: fakeAwsCredentials.SecretAccessKey,
+        sessionToken: fakeAwsCredentials.SessionToken
+      });
+    });
+    it("should handle errors when creating keys", async () => {
+      // assumeRole = jest.fn((params, callback) => callback(null, { Credentials: fakeAwsCredentials }))
+      expect.assertions(1);
+      const mockError = {error: "something failed"};
+      mockAssumeRole.mockImplementation((params, callback) => callback(mockError));
+      await expect(createAthenaResource().createKeys(config,
+        {bucket: "test-bucket", folder: "test-folder", region: "test-region", account: "12345"} as FireStoreAthenaWorkgroupSettings))
+        .rejects.toEqual(mockError);
+    });
+    it("should handle no credentials when creating keys", async () => {
+      // assumeRole = jest.fn((params, callback) => callback(null, { Credentials: fakeAwsCredentials }))
+      expect.assertions(1);
+      mockAssumeRole.mockImplementation((params, callback) => callback(undefined, {}));
+      await expect(createAthenaResource().createKeys(config,
+        {bucket: "test-bucket", folder: "test-folder", region: "test-region", account: "12345"} as FireStoreAthenaWorkgroupSettings))
+        .rejects.toMatch(/credentials/);
+    });
+
+  });
+});

--- a/functions/src/models/athena-resource-object.test.ts
+++ b/functions/src/models/athena-resource-object.test.ts
@@ -12,10 +12,8 @@ const config = {
   aws: {
     key: "test-aws-key",
     secret: "test-aws-secret",
-    s3credentials: {
-      rolearn: "test-rolearn",
-      duration: 3600
-    }
+    rolearn: "test-rolearn",
+    duration: 3600
   }
 };
 

--- a/functions/src/models/athena-resource-object.ts
+++ b/functions/src/models/athena-resource-object.ts
@@ -1,0 +1,87 @@
+import {
+  FireStoreResourceSettings,
+  FireStoreAthenaWorkgroupSettings, AuthClaims
+} from "../firestore-types";
+import {BaseResourceObject} from "./base-resource-object";
+import {
+  Config, AthenaResource
+} from "../resource-types";
+import { assumeAWSRole } from "./aws-utils"
+
+export class AthenaResourceObject extends BaseResourceObject {
+  canCreateKeys(claims: AuthClaims): boolean {
+    if ("readWriteToken" in claims) {
+      // readWriteToken
+      return false;
+    } else {
+      // JTW claims
+      return this.isOwnerOrMember(claims);
+    }
+  }
+
+  createKeys(config: Config, _settings: FireStoreResourceSettings) {
+    // Cast settings to desired type. We can't change argument type due to the way how the logic and typing is
+    // organized in resource classes. TODO: refactor all that, base class is referencing its subclasses often,
+    // causing circular dependencies and issues like this one.
+    const settings = _settings as FireStoreAthenaWorkgroupSettings;
+    const workgroupName = this.workgroupName();
+    const keyPrefix = `${settings.folder}/${workgroupName}/`
+
+    const policy = JSON.stringify({
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Sid": "AllowBucketAccess",
+          "Effect": "Allow",
+          "Action": [
+            "s3:ListBucket"
+          ],
+          "Resource": [
+            `arn:aws:s3:::${settings.bucket}`
+          ]
+        },
+        {
+          "Sid": "AllowReadInWorkgroupFolder",
+          "Action": [
+            "s3:GetObject"
+          ],
+          "Effect": "Allow",
+          "Resource": [
+            `arn:aws:s3:::${settings.bucket}/${keyPrefix}*`
+          ]
+        },
+        {
+          "Sid": "AllowListExecutions",
+          "Action": [
+            "athena:ListQueryExecutions",
+            "athena:GetQueryExecution"
+          ],
+          "Effect": "Allow",
+          "Resource": [
+            `arn:aws:athena:${settings.region}:${settings.account}:workgroup/${workgroupName}`
+          ]
+        }
+
+      ]
+    });
+
+    return assumeAWSRole(policy, settings.region, `${this.type}-${this.tool}-${this.id}`, config);
+  }
+
+  apiResult(claims: AuthClaims | undefined, _settings: FireStoreResourceSettings): AthenaResource {
+    // Cast settings to desired type. We can't change argument type due to the way how the logic and typing is
+    // organized in resource classes. TODO: refactor all that, base class is referencing its subclasses often,
+    // causing circular dependencies and issues like this one.
+    const settings = _settings as FireStoreAthenaWorkgroupSettings;
+    const result = super.apiResult(claims) as AthenaResource;
+    result.region = settings.region;
+    result.workgroupName = this.workgroupName();
+    return result;
+  }
+
+  workgroupName() {
+    const { id, name } = this;
+    return `${name}-${id}`
+  }
+
+}

--- a/functions/src/models/athena-resource-object.ts
+++ b/functions/src/models/athena-resource-object.ts
@@ -20,9 +20,8 @@ export class AthenaResourceObject extends BaseResourceObject {
   }
 
   createKeys(config: Config, _settings: FireStoreResourceSettings) {
-    // Cast settings to desired type. We can't change argument type due to the way how the logic and typing is
-    // organized in resource classes. TODO: refactor all that, base class is referencing its subclasses often,
-    // causing circular dependencies and issues like this one.
+    // TODO: see if we can change the argument type instead of casting, this will force
+    // either a cast or type guard before this method is called
     const settings = _settings as FireStoreAthenaWorkgroupSettings;
     const workgroupName = this.workgroupName();
     const keyPrefix = `${settings.folder}/${workgroupName}/`
@@ -69,9 +68,8 @@ export class AthenaResourceObject extends BaseResourceObject {
   }
 
   apiResult(claims: AuthClaims | undefined, _settings: FireStoreResourceSettings): AthenaResource {
-    // Cast settings to desired type. We can't change argument type due to the way how the logic and typing is
-    // organized in resource classes. TODO: refactor all that, base class is referencing its subclasses often,
-    // causing circular dependencies and issues like this one.
+    // TODO: see if we can change the argument type instead of casting, this will force
+    // either a cast or type guard before this method is called
     const settings = _settings as FireStoreAthenaWorkgroupSettings;
     const result = super.apiResult(claims) as AthenaResource;
     result.region = settings.region;

--- a/functions/src/models/aws-utils.ts
+++ b/functions/src/models/aws-utils.ts
@@ -1,0 +1,51 @@
+import * as crypto from "crypto";
+import {
+  Credentials, Config
+} from "../resource-types";
+import { STS } from "aws-sdk";
+
+export const assumeAWSRole = (policy: string, region: string, sessionName: string, config: Config) => {
+  return new Promise<Credentials>((resolve, reject) => {
+    // call assume role
+    const sts = new STS({
+      region,
+      endpoint: `https://sts.${region}.amazonaws.com`,
+      accessKeyId: config.aws.key,
+      secretAccessKey: config.aws.secret
+    });
+    let roleSessionName = `token-service-${sessionName}`;
+    // Max length of this value is 64, see: https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html
+    // Preprocess roleSessionName when necessary.
+    if (roleSessionName.length > 64) {
+      // md5 hash has 32 characters.
+      const md5Hash = crypto.createHash("md5").update(sessionName).digest("hex");
+      roleSessionName = `token-service-${md5Hash}`;
+    }
+    const params: STS.AssumeRoleRequest = {
+      // FIXME: the rolearn and duration should be moved to the top level aws part of the config
+      //   they will be used for all AWS not just S3.
+      DurationSeconds: config.aws.s3credentials.duration,
+      // ExternalId: // not needed
+      Policy: policy,
+      RoleArn: config.aws.s3credentials.rolearn,
+      RoleSessionName: roleSessionName
+    };
+    sts.assumeRole(params, (err, data) => {
+      if (err) {
+        reject(err);
+      }
+      else if (!data.Credentials) {
+        reject(`Missing credentials in AWS STS assume role response!`)
+      }
+      else {
+        const {AccessKeyId, Expiration, SecretAccessKey, SessionToken} = data.Credentials;
+        resolve({
+          accessKeyId: AccessKeyId,
+          expiration: Expiration,
+          secretAccessKey: SecretAccessKey,
+          sessionToken: SessionToken
+        });
+      }
+    })
+  });
+}

--- a/functions/src/models/aws-utils.ts
+++ b/functions/src/models/aws-utils.ts
@@ -22,12 +22,10 @@ export const assumeAWSRole = (policy: string, region: string, sessionName: strin
       roleSessionName = `token-service-${md5Hash}`;
     }
     const params: STS.AssumeRoleRequest = {
-      // FIXME: the rolearn and duration should be moved to the top level aws part of the config
-      //   they will be used for all AWS not just S3.
-      DurationSeconds: config.aws.s3credentials.duration,
+      DurationSeconds: config.aws.duration,
       // ExternalId: // not needed
       Policy: policy,
-      RoleArn: config.aws.s3credentials.rolearn,
+      RoleArn: config.aws.rolearn,
       RoleSessionName: roleSessionName
     };
     sts.assumeRole(params, (err, data) => {

--- a/functions/src/models/base-resource-object.test.ts
+++ b/functions/src/models/base-resource-object.test.ts
@@ -180,7 +180,5 @@ describe("Resource", () => {
         expect(createBaseResource(validReadWriteTokenRules).isReadWriteTokenValid(validReadWriteToken2)).toEqual(true);
       });
     });
-
-    // TODO: add tests for static Firestore member functions
   });
 });

--- a/functions/src/models/base-resource-object.test.ts
+++ b/functions/src/models/base-resource-object.test.ts
@@ -9,10 +9,8 @@ const config = {
   aws: {
     key: "test-aws-key",
     secret: "test-aws-secret",
-    s3credentials: {
-      rolearn: "test-rolearn",
-      duration: 3600
-    }
+    rolearn: "test-rolearn",
+    duration: 3600
   }
 };
 

--- a/functions/src/models/iot-resource-object.test.ts
+++ b/functions/src/models/iot-resource-object.test.ts
@@ -9,10 +9,8 @@ const config = {
   aws: {
     key: "test-aws-key",
     secret: "test-aws-secret",
-    s3credentials: {
-      rolearn: "test-rolearn",
-      duration: 3600
-    }
+    rolearn: "test-rolearn",
+    duration: 3600
   }
 };
 

--- a/functions/src/models/s3-resource-object.test.ts
+++ b/functions/src/models/s3-resource-object.test.ts
@@ -12,10 +12,8 @@ const config = {
   aws: {
     key: "test-aws-key",
     secret: "test-aws-secret",
-    s3credentials: {
-      rolearn: "test-rolearn",
-      duration: 3600
-    }
+    rolearn: "test-rolearn",
+    duration: 3600
   }
 };
 

--- a/functions/src/models/s3-resource-object.test.ts
+++ b/functions/src/models/s3-resource-object.test.ts
@@ -154,9 +154,7 @@ describe("Resource", () => {
       const keys = await createS3Resource().createKeys(config, {bucket: "test-bucket", folder: "test-folder", region: "test-region"} as FireStoreS3ResourceSettings);
       expect(keys).toEqual({
         accessKeyId: fakeAwsCredentials.AccessKeyId,
-        bucket: "test-bucket",
         expiration: fakeAwsCredentials.Expiration,
-        keyPrefix: "test-folder/test/",
         secretAccessKey: fakeAwsCredentials.SecretAccessKey,
         sessionToken: fakeAwsCredentials.SessionToken
       });
@@ -168,9 +166,7 @@ describe("Resource", () => {
       const keys = await resource.createKeys(config, {bucket: "test-bucket", folder: "test-folder", region: "test-region"} as FireStoreS3ResourceSettings);
       expect(keys).toEqual({
         accessKeyId: fakeAwsCredentials.AccessKeyId,
-        bucket: "test-bucket",
         expiration: fakeAwsCredentials.Expiration,
-        keyPrefix: "test-folder/test/",
         secretAccessKey: fakeAwsCredentials.SecretAccessKey,
         sessionToken: fakeAwsCredentials.SessionToken
       });

--- a/functions/src/models/s3-resource-object.ts
+++ b/functions/src/models/s3-resource-object.ts
@@ -27,9 +27,8 @@ export class S3ResourceObject extends BaseResourceObject {
   }
 
   apiResult(claims: AuthClaims | undefined, settings: FireStoreResourceSettings): S3Resource {
-    // Cast settings to desired type. We can't change argument type due to the way how the logic and typing is
-    // organized in resource classes. TODO: refactor all that, base class is referencing its subclasses often,
-    // causing circular dependencies and issues like this one.
+    // TODO: see if we can change the argument type instead of casting, this will force
+    // either a cast or type guard before this method is called
     const s3settings = settings as FireStoreS3ResourceSettings;
     const result = super.apiResult(claims) as S3Resource;
     result.bucket = s3settings.bucket;
@@ -51,9 +50,8 @@ export class S3ResourceObject extends BaseResourceObject {
   }
 
   createKeys(config: Config, settings: FireStoreResourceSettings) {
-    // Cast settings to desired type. We can't change argument type due to the way how the logic and typing is
-    // organized in resource classes. TODO: refactor all that, base class is referencing its subclasses often,
-    // causing circular dependencies and issues like this one.
+    // TODO: see if we can change the argument type instead of casting, this will force
+    // either a cast or type guard before this method is called
     const s3settings = settings as FireStoreS3ResourceSettings;
     const { id } = this;
     const keyPrefix = `${s3settings.folder}/${id}/`

--- a/functions/src/models/s3-resource-object.ts
+++ b/functions/src/models/s3-resource-object.ts
@@ -4,7 +4,7 @@ import {
 } from "../firestore-types";
 import {BaseResourceObject} from "./base-resource-object";
 import {
-  Credentials, Config, S3Resource
+  Config, S3Resource
 } from "../resource-types";
 import { assumeAWSRole } from "./aws-utils"
 
@@ -89,14 +89,6 @@ export class S3ResourceObject extends BaseResourceObject {
       ]
     });
 
-    return assumeAWSRole(policy, s3settings.region, `${this.type}-${this.tool}-${this.id}`, config)
-      .then(credentials => {
-        const s3Credentials: Credentials = { 
-          ...credentials,
-          bucket: s3settings.bucket,
-          keyPrefix
-        };
-        return s3Credentials;
-      });
+    return assumeAWSRole(policy, s3settings.region, `${this.type}-${this.tool}-${this.id}`, config);
   }
 }

--- a/functions/src/models/s3-resource-object.ts
+++ b/functions/src/models/s3-resource-object.ts
@@ -6,8 +6,7 @@ import {BaseResourceObject} from "./base-resource-object";
 import {
   Credentials, Config, S3Resource
 } from "../resource-types";
-import { STS } from "aws-sdk";
-import * as crypto from "crypto";
+import { assumeAWSRole } from "./aws-utils"
 
 export class S3ResourceObject extends BaseResourceObject {
   getPublicPath(settings: FireStoreS3ResourceSettings) {
@@ -56,82 +55,48 @@ export class S3ResourceObject extends BaseResourceObject {
     // organized in resource classes. TODO: refactor all that, base class is referencing its subclasses often,
     // causing circular dependencies and issues like this one.
     const s3settings = settings as FireStoreS3ResourceSettings;
-    return new Promise<Credentials>((resolve, reject) => {
-      const { id } = this;
-      const keyPrefix = `${s3settings.folder}/${id}/`
+    const { id } = this;
+    const keyPrefix = `${s3settings.folder}/${id}/`
 
-      const policy = JSON.stringify({
-        "Version": "2012-10-17",
-        "Statement": [
-          {
-            "Sid": "AllowBucketAccess",
-            "Effect": "Allow",
-            "Action": [
-              "s3:ListBucket",
-              "s3:ListBucketVersions"
-            ],
-            "Resource": [
-              `arn:aws:s3:::${s3settings.bucket}`
-            ]
-          },
-          {
-            "Sid": "AllowAllS3ActionsInResourceFolder",
-            "Action": [
-              "s3:DeleteObject",
-              "s3:DeleteObjectVersion",
-              "s3:GetObject",
-              "s3:GetObjectVersion",
-              "s3:PutObject"
-            ],
-            "Effect": "Allow",
-            "Resource": [
-              `arn:aws:s3:::${s3settings.bucket}/${keyPrefix}*`
-            ]
-          }
-        ]
-      });
-
-      // call assume role
-      const sts = new STS({
-        region: s3settings.region,
-        endpoint: `https://sts.${s3settings.region}.amazonaws.com`,
-        accessKeyId: config.aws.key,
-        secretAccessKey: config.aws.secret
-      });
-      let roleSessionName = `token-service-${this.type}-${this.tool}-${this.id}`;
-      // Max length of this value is 64, see: https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html
-      // Preprocess roleSessionName when necessary.
-      if (roleSessionName.length > 64) {
-        // md5 hash has 32 characters.
-        const md5Hash = crypto.createHash("md5").update(`${this.type}-${this.tool}-${this.id}`).digest("hex");
-        roleSessionName = `token-service-${md5Hash}`;
-      }
-      const params: STS.AssumeRoleRequest = {
-        DurationSeconds: config.aws.s3credentials.duration,
-        // ExternalId: // not needed
-        Policy: policy,
-        RoleArn: config.aws.s3credentials.rolearn,
-        RoleSessionName: roleSessionName
-      };
-      sts.assumeRole(params, (err, data) => {
-        if (err) {
-          reject(err);
+    const policy = JSON.stringify({
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Sid": "AllowBucketAccess",
+          "Effect": "Allow",
+          "Action": [
+            "s3:ListBucket",
+            "s3:ListBucketVersions"
+          ],
+          "Resource": [
+            `arn:aws:s3:::${s3settings.bucket}`
+          ]
+        },
+        {
+          "Sid": "AllowAllS3ActionsInResourceFolder",
+          "Action": [
+            "s3:DeleteObject",
+            "s3:DeleteObjectVersion",
+            "s3:GetObject",
+            "s3:GetObjectVersion",
+            "s3:PutObject"
+          ],
+          "Effect": "Allow",
+          "Resource": [
+            `arn:aws:s3:::${s3settings.bucket}/${keyPrefix}*`
+          ]
         }
-        else if (!data.Credentials) {
-          reject(`Missing credentials in AWS STS assume role response!`)
-        }
-        else {
-          const {AccessKeyId, Expiration, SecretAccessKey, SessionToken} = data.Credentials;
-          resolve({
-            accessKeyId: AccessKeyId,
-            expiration: Expiration,
-            secretAccessKey: SecretAccessKey,
-            sessionToken: SessionToken,
-            bucket: s3settings.bucket,
-            keyPrefix
-          });
-        }
-      })
+      ]
     });
+
+    return assumeAWSRole(policy, s3settings.region, `${this.type}-${this.tool}-${this.id}`, config)
+      .then(credentials => {
+        const s3Credentials: Credentials = { 
+          ...credentials,
+          bucket: s3settings.bucket,
+          keyPrefix
+        };
+        return s3Credentials;
+      });
   }
 }

--- a/functions/src/resource-manager.ts
+++ b/functions/src/resource-manager.ts
@@ -3,6 +3,7 @@ import {
 } from "./firestore-types";
 import { S3ResourceObject } from "./models/s3-resource-object";
 import { IotResourceObject } from "./models/iot-resource-object";
+import { AthenaResourceObject } from "./models/athena-resource-object";
 import {
   ResourceType,
   FindAllQuery, CreateQuery, UpdateQuery, Credentials, Config,
@@ -10,7 +11,7 @@ import {
 } from "./resource-types";
 import * as crypto from "crypto";
 
-export type ResourceObject = S3ResourceObject | IotResourceObject;
+export type ResourceObject = S3ResourceObject | IotResourceObject | AthenaResourceObject;
 
 const RESOURCE_COLLECTION_ID = 'resources';
 const RESOURCE_SETTINGS_COLLECTION_ID = 'resourceSettings';
@@ -47,6 +48,10 @@ export const fromDocumentSnapshot = (doc: FirebaseFirestore.DocumentSnapshot) =>
     case "iotOrganization":
       // tslint:disable-next-line: no-use-before-declare
       return new IotResourceObject(doc.id, data);
+
+    case "athenaWorkgroup":
+      // tslint:disable-next-line: no-use-before-declare
+      return new AthenaResourceObject(doc.id, data);
   }
 }
 
@@ -131,7 +136,7 @@ export const createResource = (db: FirebaseFirestore.Firestore, env: string, cla
         }
 
         // FIXME: centralize this list of types, it is also used in fromDocumentSnapshot
-        if (type !== "s3Folder" && type !== "iotOrganization") {
+        if (type !== "s3Folder" && type !== "iotOrganization" && type !== "athenaWorkgroup") {
           reject(`Unknown resource type: ${type}`);
           return;
         }

--- a/functions/src/resource-manager.ts
+++ b/functions/src/resource-manager.ts
@@ -38,21 +38,18 @@ export const getResourceSettings = (db: FirebaseFirestore.Firestore, env: string
   });
 }
 
+const resourceTypeObjects = {
+  s3Folder: S3ResourceObject,
+  iotOrganization: IotResourceObject,
+  athenaWorkgroup: AthenaResourceObject
+} as const;
+const resourceTypes = Object.keys(resourceTypeObjects);
+
 export const fromDocumentSnapshot = (doc: FirebaseFirestore.DocumentSnapshot) => {
   const data: FireStoreResource = doc.data() as FireStoreResource;
-  switch (data.type) {
-    case "s3Folder":
-      // tslint:disable-next-line: no-use-before-declare
-      return new S3ResourceObject(doc.id, data);
-
-    case "iotOrganization":
-      // tslint:disable-next-line: no-use-before-declare
-      return new IotResourceObject(doc.id, data);
-
-    case "athenaWorkgroup":
-      // tslint:disable-next-line: no-use-before-declare
-      return new AthenaResourceObject(doc.id, data);
-  }
+  const constructor = resourceTypeObjects[data.type];
+  // tslint:disable-next-line: no-use-before-declare
+  return new constructor(doc.id, data);
 }
 
 export const findResource = (db: FirebaseFirestore.Firestore, env: string, id: string) => {
@@ -135,8 +132,7 @@ export const createResource = (db: FirebaseFirestore.Firestore, env: string, cla
           return;
         }
 
-        // FIXME: centralize this list of types, it is also used in fromDocumentSnapshot
-        if (type !== "s3Folder" && type !== "iotOrganization" && type !== "athenaWorkgroup") {
+        if (!resourceTypes.includes(type)) {
           reject(`Unknown resource type: ${type}`);
           return;
         }

--- a/functions/src/resource-types.ts
+++ b/functions/src/resource-types.ts
@@ -61,12 +61,6 @@ export interface Credentials {
   expiration: Date;
   secretAccessKey: string;
   sessionToken: string;
-  // FIXME: S3 properties are included in the Credentials for S3Resources,
-  //  this seems unnecessary since the Resource used to fetch the credentials also
-  //  has the bucket, it doesn't have the keyPrefix, but we could add it.  This
-  //  Credentials object is used for non S3 Resources too.
-  bucket?: string;
-  keyPrefix?: string;
 }
 
 export type ResourceType = "s3Folder" | "iotOrganization" | "athenaWorkgroup";

--- a/functions/src/resource-types.ts
+++ b/functions/src/resource-types.ts
@@ -9,6 +9,7 @@ export interface Config {
   aws: {
     key: string;
     secret: string;
+    // FIXME: These settings are used not just for S3 but also Athena
     s3credentials: {
       rolearn: string;
       duration: number;
@@ -37,6 +38,11 @@ export interface S3Resource extends BaseResource {
 export interface IotResource extends BaseResource {
 }
 
+export interface AthenaResource extends BaseResource {
+  region: string;
+  workgroupName: string;
+}
+
 export interface FindAllQuery {
   name?: string;
   type?: ResourceType;
@@ -58,11 +64,15 @@ export interface Credentials {
   expiration: Date;
   secretAccessKey: string;
   sessionToken: string;
-  bucket: string;
-  keyPrefix: string;
+  // FIXME: S3 properties are included in the Credentials for S3Resources,
+  //  this seems unnecessary since the Resource used to fetch the credentials also
+  //  has the bucket, it doesn't have the keyPrefix, but we could add it.  This
+  //  Credentials object is used for non S3 Resources too.
+  bucket?: string;
+  keyPrefix?: string;
 }
 
-export type ResourceType = "s3Folder" | "iotOrganization";
+export type ResourceType = "s3Folder" | "iotOrganization" | "athenaWorkgroup";
 export type AccessRuleType = "user" | "readWriteToken";
 export type AccessRuleRole = "owner" | "member";
 

--- a/functions/src/resource-types.ts
+++ b/functions/src/resource-types.ts
@@ -9,11 +9,8 @@ export interface Config {
   aws: {
     key: string;
     secret: string;
-    // FIXME: These settings are used not just for S3 but also Athena
-    s3credentials: {
-      rolearn: string;
-      duration: number;
-    }
+    rolearn: string;
+    duration: number;
   }
 }
 


### PR DESCRIPTION
This also refactors the S3ResourceObject so they can share the code to
call STS to get temporary credentials.

It also includes some non-backwards compatible changes:
- the config is changed so the s3credentials object properties are moved up a level, I've updated the staging and production configs to have these properties at both levels
- the credentials object returned by the api no longer has S3 specific properties in it. I checked all of our apps using the client and none of them used these properties.  I'm planning to bump the version of the client to 2.0.0 because this change isn't backward compatible. It seems like a small reason to bump the major version number, but why not. :) 

I left some TODOs in the code because I need to move on.

TODO:
- [x] move s3credentials property from config to the top level
- [x] try to remove S3 specific props from the Credentials object
- [x] centralize the list of resource types