### PR TITLE
Make client isomorphic as a node library

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -70,6 +70,9 @@ export class TokenServiceClient {
     this.env = options.env || getEnv();
     this.serviceUrl = getServiceUrlFromQueryString() || serviceUrl || getServiceUrlFromEnv(this.env) || serviceUrls.production;
     this.fetch = ("fetch" in options) ? options.fetch : fetch;
+    if (!this.fetch) {
+      throw new Error("fetch not found in options or window object");
+    }
   }
 
   static get FirebaseAppName() {


### PR DESCRIPTION
This allows the client library to be used in node applications, with the small change that `env` will be required, and the application will need to pass in an isomorphic replacement for `fetch` (presumably `node-fetch`).