### PR TITLE
Private example app

### DIFF
--- a/example-app/src/index.tsx
+++ b/example-app/src/index.tsx
@@ -37,6 +37,14 @@ const AppComponent = () => {
     setPortalAccessToken(helpers.readPortalAccessToken());
   }, []);
 
+  useEffect(() => {
+    // Reset state related to the main params.
+    setResources({});
+    setResourcesStatus("use button to load list");
+    setCurrentResource(undefined);
+    setCredentials(undefined);
+  }, [rawTool, rawTokenServiceEnv, resourceType]);
+
   const handleAuthorizeInPortal = () => {
     helpers.authorizeInPortal(portalUrl, oauthClientName);
   };

--- a/example-app/src/s3-demo.tsx
+++ b/example-app/src/s3-demo.tsx
@@ -1,26 +1,28 @@
 import React, { useState } from "react";
-import * as helpers from "./helpers";
 import { Section, useInput } from "./form";
-import { S3Resource, EnvironmentName, ResourceType, Credentials } from "@concord-consortium/token-service";
-import { uploadS3File, deleteS3File, listS3Files } from "./s3-helpers";
+import { S3Resource, Credentials } from "@concord-consortium/token-service";
+import { uploadS3File, deleteS3File, listS3Files, SIGNED_URL_EXPIRES, IListResult } from "./s3-helpers";
 
 interface S3DemoProps {
   credentials?: Credentials;
   s3Resource?: S3Resource;
+  showSignedUrl?: boolean;
 }
 
 export const S3Demo : React.FunctionComponent<S3DemoProps> = props => {
   const [filename, filenameProps] = useInput("test.txt");
   const [fileContent, fileContentProps] = useInput("Hello world");
   const [filePublicUrl, setFilePublicUrl] = useState("");
-  const [files, setFiles] = useState<string[] | undefined>();
+  const [fileSignedUrl, setFileSignedUrl] = useState("");
+  const [files, setFiles] = useState<IListResult[] | undefined>();
 
-  const {credentials, s3Resource} = props;
+  const {credentials, s3Resource, showSignedUrl} = props;
 
   const handleCreateOrUpdateS3File = async () => {
     if (!credentials || !s3Resource) return;
     const result = await uploadS3File({ filename, fileContent, s3Resource, credentials });
     setFilePublicUrl(result.publicUrl);
+    setFileSignedUrl(result.signedUrl);
   };
 
   const handleDeleteS3File = async () => {
@@ -43,7 +45,8 @@ export const S3Demo : React.FunctionComponent<S3DemoProps> = props => {
       <p>
         <button onClick={handleCreateOrUpdateS3File}>Create or Update File</button>
       </p>
-      { filePublicUrl && <a target="_blank" href={filePublicUrl}>{filePublicUrl}</a> }
+      { filePublicUrl && <div>Public URL: <a target="_blank" href={filePublicUrl}>{filePublicUrl}</a></div> }
+      { showSignedUrl && fileSignedUrl && <div>Signed URL (expires in { SIGNED_URL_EXPIRES } seconds): <a target="_blank" href={fileSignedUrl}>{fileSignedUrl.slice(0, 120)}...</a></div> }
     </Section>
 
     <Section title="Delete File">
@@ -60,7 +63,8 @@ export const S3Demo : React.FunctionComponent<S3DemoProps> = props => {
       { files ?
           <ul>
             { files.map(file =>
-              <li key={file}>{file}</li>
+              <li key={file.key}>{file.key} <a target="_blank" href={file.publicUrl}>Public URL</a> { showSignedUrl && <a target="_blank" href={file.signedUrl}>Signed URL</a> }
+              </li>
             )}
           </ul>
         :

--- a/example-app/src/s3-demo.tsx
+++ b/example-app/src/s3-demo.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Section, useInput } from "./form";
 import { S3Resource, Credentials } from "@concord-consortium/token-service";
 import { uploadS3File, deleteS3File, listS3Files, SIGNED_URL_EXPIRES, IListResult } from "./s3-helpers";
@@ -17,6 +17,13 @@ export const S3Demo : React.FunctionComponent<S3DemoProps> = props => {
   const [files, setFiles] = useState<IListResult[] | undefined>();
 
   const {credentials, s3Resource, showSignedUrl} = props;
+
+  useEffect(() => {
+    // Reset state when resource changes.
+    setFiles(undefined);
+    setFilePublicUrl("");
+    setFileSignedUrl("");
+  }, [s3Resource]);
 
   const handleCreateOrUpdateS3File = async () => {
     if (!credentials || !s3Resource) return;


### PR DESCRIPTION
This PR improves the example app. Now it's possible to pick `example-app-private` tool that uses an S3 bucket that doesn't have public access. When it's selected, users will also see signed URLs when they upload or list files. I've also made a small change to some state / UI handling when one of the main parameters is updated (for example a `tool` that has been just added now).

Necessary changes in AWS (might be useful when we configure that on production):
- an S3 private bucket needs to be crated
- CORS rules need to be added to the new bucket
- token-service IAM role needs to be updated to be able to access the new S3 bucket

Then, a new resource configuration in Firestore can use this bucket and things should just work fine.