### PR TITLE
Add support of target_user_id claim + tests

### DIFF
--- a/functions/src/firestore-types.ts
+++ b/functions/src/firestore-types.ts
@@ -60,7 +60,10 @@ export interface JWTClaims {
   platform_user_id: string;
   platform_id: string | number;
   user_id: string | number;
+  // class_hash is a Portal's name of context id
   class_hash?: string;
+  // Usually only researchers will have this claim. It gives them an access to data of user specified by target_user_id.
+  target_user_id?: string | number;
 }
 
 export interface ReadWriteTokenClaims {

--- a/functions/src/models/athena-resource-object.ts
+++ b/functions/src/models/athena-resource-object.ts
@@ -15,7 +15,7 @@ export class AthenaResourceObject extends BaseResourceObject {
       return false;
     } else {
       // JTW claims
-      return this.isOwnerOrMember(claims);
+      return this.isOwner(claims) || this.isMember(claims) || this.isContextMember(claims) || this.hasAccessToTargetUserData(claims);
     }
   }
 

--- a/functions/src/models/base-resource-object.test.ts
+++ b/functions/src/models/base-resource-object.test.ts
@@ -114,7 +114,8 @@ const validClaims: JWTClaims = {
 };
 const validClaimsWithTargetUserId: JWTClaims = {
   platform_id: "test-platform-id",
-  platform_user_id: "researcher",
+  platform_user_id: "researcher-1",
+  user_id: "researcher-1",
   target_user_id: "test-user-id",
   class_hash: "test-context-id"
 };

--- a/functions/src/models/base-resource-object.test.ts
+++ b/functions/src/models/base-resource-object.test.ts
@@ -112,6 +112,12 @@ const validClaims: JWTClaims = {
   user_id: "test-user-id",
   class_hash: "test-context-id"
 };
+const validClaimsWithTargetUserId: JWTClaims = {
+  platform_id: "test-platform-id",
+  platform_user_id: "researcher",
+  target_user_id: "test-user-id",
+  class_hash: "test-context-id"
+};
 
 const createBaseResource = (accessRules: AccessRule[] = []) => {
   return new BaseResourceObject("test", {
@@ -170,41 +176,39 @@ describe("Resource", () => {
     describe("#isOwner", () => {
       it("should fail with invalid claims", () => {
         expect(createBaseResource(validOwnerAccessRules).isOwner(invalidClaims)).toEqual(false);
+        expect(createBaseResource(invalidOwnerAccessRules).isOwner(validClaims)).toEqual(false);
       });
       it("should succeed with valid claims", () => {
         expect(createBaseResource(validOwnerAccessRules).isOwner(validClaims)).toEqual(true);
       });
     });
 
-    describe("#isOwnerOrMember", () => {
-      it("should fail with invalid owner access rules and valid claims", () => {
-        expect(createBaseResource(invalidOwnerAccessRules).isOwnerOrMember(validClaims)).toEqual(false);
+    describe("#isMember", () => {
+      it("should fail with invalid claims", () => {
+        expect(createBaseResource(validMemberAccessRules).isMember(invalidClaims)).toEqual(false);
+        expect(createBaseResource(invalidMemberAccessRules).isMember(validClaims)).toEqual(false);
       });
-      it("should fail with valid owner access rules and invalid claims", () => {
-        expect(createBaseResource(validOwnerAccessRules).isOwnerOrMember(invalidClaims)).toEqual(false);
+      it("should succeed with valid claims", () => {
+        expect(createBaseResource(validMemberAccessRules).isMember(validClaims)).toEqual(true);
       });
-      it("should succeed with valid owner access rules and valid claims", () => {
-        expect(createBaseResource(validOwnerAccessRules).isOwnerOrMember(validClaims)).toEqual(true);
-      });
+    });
 
-      it("should fail with invalid member access rules and valid claims", () => {
-        expect(createBaseResource(invalidMemberAccessRules).isOwnerOrMember(validClaims)).toEqual(false);
+    describe("#isContextMember", () => {
+      it("should fail if context access rule doesn't match claims", () => {
+        expect(createBaseResource(invalidContextAccessRules).isContextMember(validClaims)).toEqual(false);
+        expect(createBaseResource(validContextAccessRules).isContextMember(invalidClaims)).toEqual(false);
       });
-      it("should fail with valid member access rules and invalid claims", () => {
-        expect(createBaseResource(validMemberAccessRules).isOwnerOrMember(invalidClaims)).toEqual(false);
+      it("should succeed when context access rule matches claims", () => {
+        expect(createBaseResource(validContextAccessRules).isContextMember(validClaims)).toEqual(true);
       });
-      it("should succeed with valid member access rules and valid claims", () => {
-        expect(createBaseResource(validMemberAccessRules).isOwnerOrMember(validClaims)).toEqual(true);
-      });
+    });
 
-      it("should fail with invalid context access rules and valid claims", () => {
-        expect(createBaseResource(invalidContextAccessRules).isOwnerOrMember(validClaims)).toEqual(false);
+    describe("#hasAccessToTargetUserData", () => {
+      it("should fail if owner access rule doesn't match claims with target_user_id", () => {
+        expect(createBaseResource(invalidOwnerAccessRules).hasAccessToTargetUserData(validClaimsWithTargetUserId)).toEqual(false);
       });
-      it("should fail with valid context access rules and invalid claims", () => {
-        expect(createBaseResource(validContextAccessRules).isOwnerOrMember(invalidClaims)).toEqual(false);
-      });
-      it("should succeed with valid context access rules and valid claims", () => {
-        expect(createBaseResource(validContextAccessRules).isOwnerOrMember(validClaims)).toEqual(true);
+      it("should succeed when owner access rule matches claims with target_user_id", () => {
+        expect(createBaseResource(validOwnerAccessRules).hasAccessToTargetUserData(validClaimsWithTargetUserId)).toEqual(true);
       });
     });
 
@@ -219,16 +223,6 @@ describe("Resource", () => {
       it("should succeed with valid token", () => {
         expect(createBaseResource(validReadWriteTokenRules).isReadWriteTokenValid(validReadWriteToken1)).toEqual(true);
         expect(createBaseResource(validReadWriteTokenRules).isReadWriteTokenValid(validReadWriteToken2)).toEqual(true);
-      });
-    });
-
-    describe("#isContextMember", () => {
-      it("should fail if context access rule doesn't match claims", () => {
-        expect(createBaseResource(invalidContextAccessRules).isContextMember(validClaims)).toEqual(false);
-        expect(createBaseResource(validContextAccessRules).isContextMember(invalidClaims)).toEqual(false);
-      });
-      it("should succeed when context access rule matches claims", () => {
-        expect(createBaseResource(validContextAccessRules).isContextMember(validClaims)).toEqual(true);
       });
     });
   });

--- a/functions/src/models/base-resource-object.ts
+++ b/functions/src/models/base-resource-object.ts
@@ -88,14 +88,21 @@ export class BaseResourceObject implements BaseResource {
     return this.hasUserRole(claims, "owner");
   }
 
-  isOwnerOrMember(claims: JWTClaims): boolean {
-    return this.hasUserRole(claims, "owner") || this.hasUserRole(claims, "member") || this.isContextMember(claims);
+  isMember(claims: JWTClaims): boolean {
+    return this.hasUserRole(claims, "member");
   }
 
   isContextMember(claims: JWTClaims): boolean {
     return !!this.accessRules.find((accessRule) =>
       // class_hash is a Portal name for context_id
       (accessRule.type === "context") && (accessRule.platformId === claims.platform_id)  && (accessRule.contextId === claims.class_hash)
+    );
+  }
+
+  hasAccessToTargetUserData(claims: JWTClaims): boolean {
+    // Usually researchers or teachers will have target_user_id specified in their claims.
+    return !!this.accessRules.find((accessRule) =>
+      (accessRule.type === "user") && (accessRule.role === "owner") && (accessRule.userId === claims.target_user_id) && (accessRule.platformId === claims.platform_id)
     );
   }
 

--- a/functions/src/models/s3-resource-object.ts
+++ b/functions/src/models/s3-resource-object.ts
@@ -45,7 +45,7 @@ export class S3ResourceObject extends BaseResourceObject {
       return this.isReadWriteTokenValid(claims.readWriteToken);
     } else {
       // JTW claims
-      return this.isOwnerOrMember(claims);
+      return this.isOwner(claims) || this.isMember(claims) || this.isContextMember(claims) || this.hasAccessToTargetUserData(claims);
     }
   }
 


### PR DESCRIPTION
[#179181398]

If the user has `target_user_id` claim, he would be able to download AWS credentials.
I'm not specifying any new rule access rule type. It's based on the owner rule. If it adds some value, we could actually disable or enable target_user_id access in resource settings. But not sure if it's worth it unless we want to explicitly disable it somewhere.

Some other changes:
- I've removed `isOwnerOrMember` helper and related tests. It felt overloaded at this point. canCreateKeys use other methods directly. Tests assertions have been redistributed to correct places (they were in fact replicating other tests, as it was OR join of few methods), so no tests have been lost I hope.
- `index.tests.ts` has a new JWT claim - `jwtTokenWithTargetUserId`. It's a different pattern than most of the old tests used. They seemed to simulate access using rules. This time I've tried to use a different JWT, as it didn't feel right to include `target_user_id` to the default `jwtToken` used by most of the tests. And setup would be more confusing. In fact, we could actually refactor most of the tets to use different JWTs (like `jwtTokenContextMember`, `jwtTokenMember`, etc.). I think it's pretty symmetric, but probably easier to type JWT name in a new test rather than copy and modify the array of access rules. 